### PR TITLE
authentication: add support for agent authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,17 @@ following format:
 
 ```json
 {
-  "messages": ["{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"id\":1}"],
   "type":"Input"
+  "messages": ["{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"id\":1}"],
+  "user": {
+    "name": "joe",
+    "claims": ["email=joe@acme.com", "group=mcp-users"]
+  }
 }
 ```
 
-> NOTE: for a response from the MCP Server, the `type` will be set to `Output`.
+> NOTE: for a response from the MCP Server, the `type` will be set to `Output`
+and no user will be passed.
 
 The Policer must respond with an HTTP status code `200 OK` if the request passes
 the policy checks. Any other status code will be treated as a failure, and the

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/gorilla/websocket v1.5.3
 	github.com/smallnest/ringbuffer v0.0.0-20250317021400-0da97b586904
+	github.com/spaolacci/murmur3 v1.1.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.1
@@ -91,7 +92,6 @@ require (
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/skeema/knownhosts v1.3.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
-	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect

--- a/internal/cmd/aio.go
+++ b/internal/cmd/aio.go
@@ -38,6 +38,7 @@ func init() {
 	AIO.Flags().AddFlagSet(fHealth)
 	AIO.Flags().AddFlagSet(fProfiler)
 	AIO.Flags().AddFlagSet(fJWTVerifier)
+	AIO.Flags().AddFlagSet(fCORS)
 }
 
 var AIO = &cobra.Command{
@@ -92,6 +93,8 @@ var AIO = &cobra.Command{
 		}
 
 		frontendClientTLSConfig.RootCAs = trustPool
+
+		corsPolicy := makeCORSPolicy()
 
 		startHelperServers(ctx)
 
@@ -152,6 +155,7 @@ var AIO = &cobra.Command{
 					frontend.OptSSEMessageEndpoint(messageEndpoint),
 					frontend.OptSSEAgentToken(agentToken),
 					frontend.OptSSEAgentTokenPassthrough(true),
+					frontend.OptSSECORSPolicy(corsPolicy),
 				)
 			} else {
 

--- a/internal/cmd/backend.go
+++ b/internal/cmd/backend.go
@@ -17,7 +17,7 @@ func init() {
 
 	initSharedFlagSet()
 
-	fBackend.String("listen", ":8000", "Listen address of the bridge for incoming connections")
+	fBackend.StringP("listen", "l", ":8000", "Listen address of the bridge for incoming connections")
 
 	Backend.Flags().AddFlagSet(fBackend)
 	Backend.Flags().AddFlagSet(fPolicer)

--- a/internal/cmd/backend.go
+++ b/internal/cmd/backend.go
@@ -25,6 +25,7 @@ func init() {
 	Backend.Flags().AddFlagSet(fHealth)
 	Backend.Flags().AddFlagSet(fProfiler)
 	Backend.Flags().AddFlagSet(fJWTVerifier)
+	Backend.Flags().AddFlagSet(fCORS)
 }
 
 // Backend is the cobra command to run the server.
@@ -57,6 +58,8 @@ var Backend = &cobra.Command{
 			return fmt.Errorf("unable to make policer: %w", err)
 		}
 
+		corsPolicy := makeCORSPolicy()
+
 		startHelperServers(cmd.Context())
 
 		mcpServer := client.MCPServer{Command: args[0], Args: args[1:]}
@@ -74,6 +77,7 @@ var Backend = &cobra.Command{
 			backend.OptWSPolicer(policer),
 			backend.OptWSDumpStderrOnError(viper.GetString("log-format") != "json"),
 			backend.OptWSAuth(jwks, jwtVerifierConfig.principalClaim, jwtVerifierConfig.reqIss, jwtVerifierConfig.reqAud),
+			backend.OptWSCORSPolicy(corsPolicy),
 		)
 
 		return proxy.Start(cmd.Context())

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"os"
+)
+
+var Completion = &cobra.Command{
+	Use:                   "completion [bash|zsh|fish|powershell]",
+	Short:                 "Generate completion script",
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+	},
+}

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -11,16 +11,18 @@ var Completion = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		switch args[0] {
 		case "bash":
-			cmd.Root().GenBashCompletion(os.Stdout)
+			return cmd.Root().GenBashCompletion(os.Stdout)
 		case "zsh":
-			cmd.Root().GenZshCompletion(os.Stdout)
+			return cmd.Root().GenZshCompletion(os.Stdout)
 		case "fish":
-			cmd.Root().GenFishCompletion(os.Stdout, true)
+			return cmd.Root().GenFishCompletion(os.Stdout, true)
 		case "powershell":
-			cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
 		}
+
+		return nil
 	},
 }

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -11,6 +11,7 @@ var (
 	fHealth      = pflag.NewFlagSet("health", pflag.ExitOnError)
 	fPolicer     = pflag.NewFlagSet("police", pflag.ExitOnError)
 	fJWTVerifier = pflag.NewFlagSet("jwtverifier", pflag.ExitOnError)
+	fCORS        = pflag.NewFlagSet("cors", pflag.ExitOnError)
 
 	initialized = false
 )
@@ -52,4 +53,6 @@ func initSharedFlagSet() {
 	fJWTVerifier.StringP("auth-jwt-required-audience", "A", "", "Sets the required audience in the JWT when auth is enabled")
 	fJWTVerifier.StringP("auth-jwt-principal-claim", "S", "", "Sets the identity claim to use to extract the principal user name when auth is enabled")
 	fJWTVerifier.Bool("auth-jwks-insecure-skip-verify", false, "Don't validate the JWKS CA. Don't do this.")
+
+	fCORS.String("cors-origin", "*", "Sets the valid HTTP Origin for CORS")
 }

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -23,33 +23,33 @@ func initSharedFlagSet() {
 
 	initialized = true
 
-	fTLSServer.String("cert", "", "Path to the server certificate")
-	fTLSServer.String("key", "", "Path to the key for the certificate")
-	fTLSServer.String("key-pass", "", "Passphrase for the key")
-	fTLSServer.String("client-ca", "", "Path to a CA to validate client connections")
+	fTLSServer.StringP("tls-server-cert", "c", "", "Path to the server certificate")
+	fTLSServer.StringP("tls-server-key", "k", "", "Path to the key for the certificate")
+	fTLSServer.StringP("tls-server-key-pass", "p", "", "Passphrase for the key")
+	fTLSServer.String("tls-server-client-ca", "", "Path to a CA to validate client connections")
 
-	fTLSClient.String("client-cert", "", "Path to the client certificate")
-	fTLSClient.String("client-key", "", "Path to the key for the certificate")
-	fTLSClient.String("client-key-pass", "", "Passphrase for the key")
-	fTLSClient.String("server-ca", "", "Path to a CA to validate server connections")
-	fTLSClient.Bool("insecure-skip-verify", false, "If set, don't validate server's CA. Do not do this.")
+	fTLSClient.StringP("tls-client-cert", "C", "", "Path to the client certificate")
+	fTLSClient.StringP("tls-client-key", "K", "", "Path to the key for the certificate")
+	fTLSClient.StringP("tls-client-key-pass", "P", "", "Passphrase for the key")
+	fTLSClient.String("tls-client-server-ca", "", "Path to a CA to validate server connections")
+	fTLSClient.Bool("tls-insecure-skip-verify", false, "If set, don't validate server's CA. Do not do this.")
 
-	fHealth.Bool("health-enable", false, "If set, start a health server for production deployments")
 	fHealth.String("health-listen", ":8080", "Listen address of the health server")
+	fHealth.Bool("health-enable", false, "If set, start a health server for production deployments")
 
-	fProfiler.Bool("profiling-enable", false, "If set, enable profiling server")
 	fProfiler.String("profiling-listen", ":6060", "Listen address of the health server")
+	fProfiler.Bool("profiling-enable", false, "If set, enable profiling server")
 
-	fPolicer.String("policer-url", "", "Address of a Policer to send the traffic to for authentication and/or analysis")
-	fPolicer.String("policer-token", "", "Token to use to authenticate against the Policer")
+	fPolicer.StringP("policer-url", "U", "", "Address of a Policer to send the traffic to for authentication and/or analysis")
+	fPolicer.StringP("policer-token", "T", "", "Token to use to authenticate against the Policer")
 	fPolicer.String("policer-ca", "", "CA to trust Policer server certificates")
 	fPolicer.String("policer-insecure-skip-verify", "", "Do not validate Policer CA. Do not do this")
 
-	fJWTVerifier.String("jwks-url", "", "If set, enables authentication and require JWT signed by a certificate in the given JWKS")
-	fJWTVerifier.String("jwks-ca", "", "If set, use the certificates in the provided PEM to trust the remote JWKS")
-	fJWTVerifier.Bool("jwks-insecure-skip-verify", false, "Don't validate the JWKS CA. Don't do this.")
-	fJWTVerifier.String("jwt-cert", "", "If set, enables authentication and require JWT signed by the given certificate")
-	fJWTVerifier.String("jwt-required-issuer", "", "Sets the required issuer in the JWT when auth is enabled")
-	fJWTVerifier.String("jwt-required-audience", "", "Sets the required audience in the JWT when auth is enabled")
-	fJWTVerifier.String("jwt-principal-claim", "", "Sets the identity claim to use to extract the principal user name when auth is enabled")
+	fJWTVerifier.StringP("auth-jwks-url", "J", "", "If set, enables authentication and require JWT signed by a certificate in the given JWKS")
+	fJWTVerifier.String("auth-jwks-ca", "", "If set, use the certificates in the provided PEM to trust the remote JWKS")
+	fJWTVerifier.String("auth-jwt-cert", "", "If set, enables authentication and require JWT signed by the given certificate")
+	fJWTVerifier.StringP("auth-jwt-required-issuer", "I", "", "Sets the required issuer in the JWT when auth is enabled")
+	fJWTVerifier.StringP("auth-jwt-required-audience", "A", "", "Sets the required audience in the JWT when auth is enabled")
+	fJWTVerifier.StringP("auth-jwt-principal-claim", "S", "", "Sets the identity claim to use to extract the principal user name when auth is enabled")
+	fJWTVerifier.Bool("auth-jwks-insecure-skip-verify", false, "Don't validate the JWKS CA. Don't do this.")
 }

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -33,7 +33,7 @@ func initSharedFlagSet() {
 	fTLSClient.StringP("tls-client-key", "K", "", "Path to the key for the certificate")
 	fTLSClient.StringP("tls-client-key-pass", "P", "", "Passphrase for the key")
 	fTLSClient.String("tls-client-server-ca", "", "Path to a CA to validate server connections")
-	fTLSClient.Bool("tls-insecure-skip-verify", false, "If set, don't validate server's CA. Do not do this.")
+	fTLSClient.Bool("tls-client-insecure-skip-verify", false, "If set, don't validate server's CA. Do not do this.")
 
 	fHealth.String("health-listen", ":8080", "Listen address of the health server")
 	fHealth.Bool("health-enable", false, "If set, start a health server for production deployments")

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -5,11 +5,12 @@ import (
 )
 
 var (
-	fTLSClient = pflag.NewFlagSet("tlsclient", pflag.ExitOnError)
-	fTLSServer = pflag.NewFlagSet("tlsserver", pflag.ExitOnError)
-	fProfiler  = pflag.NewFlagSet("profile", pflag.ExitOnError)
-	fHealth    = pflag.NewFlagSet("health", pflag.ExitOnError)
-	fPolicer   = pflag.NewFlagSet("police", pflag.ExitOnError)
+	fTLSClient   = pflag.NewFlagSet("tlsclient", pflag.ExitOnError)
+	fTLSServer   = pflag.NewFlagSet("tlsserver", pflag.ExitOnError)
+	fProfiler    = pflag.NewFlagSet("profile", pflag.ExitOnError)
+	fHealth      = pflag.NewFlagSet("health", pflag.ExitOnError)
+	fPolicer     = pflag.NewFlagSet("police", pflag.ExitOnError)
+	fJWTVerifier = pflag.NewFlagSet("jwtverifier", pflag.ExitOnError)
 
 	initialized = false
 )
@@ -43,4 +44,12 @@ func initSharedFlagSet() {
 	fPolicer.String("policer-token", "", "Token to use to authenticate against the Policer")
 	fPolicer.String("policer-ca", "", "CA to trust Policer server certificates")
 	fPolicer.String("policer-insecure-skip-verify", "", "Do not validate Policer CA. Do not do this")
+
+	fJWTVerifier.String("jwks-url", "", "If set, enables authentication and require JWT signed by a certificate in the given JWKS")
+	fJWTVerifier.String("jwks-ca", "", "If set, use the certificates in the provided PEM to trust the remote JWKS")
+	fJWTVerifier.Bool("jwks-insecure-skip-verify", false, "Don't validate the JWKS CA. Don't do this.")
+	fJWTVerifier.String("jwt-cert", "", "If set, enables authentication and require JWT signed by the given certificate")
+	fJWTVerifier.String("jwt-required-issuer", "", "Sets the required issuer in the JWT when auth is enabled")
+	fJWTVerifier.String("jwt-required-audience", "", "Sets the required audience in the JWT when auth is enabled")
+	fJWTVerifier.String("jwt-principal-claim", "", "Sets the identity claim to use to extract the principal user name when auth is enabled")
 }

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -28,13 +28,13 @@ func initSharedFlagSet() {
 	fTLSServer.StringP("tls-server-cert", "c", "", "path to the server certificate for incoming HTTPS connections.")
 	fTLSServer.StringP("tls-server-key", "k", "", "path to the key for the server certificate.")
 	fTLSServer.StringP("tls-server-key-pass", "p", "", "passphrase for the server certificate key.")
-	fTLSServer.String("tls-server-client-ca", "", "path to a CA to validate incoming client certificate. When enabled clients must send a valid certificate.")
+	fTLSServer.String("tls-server-client-ca", "", "path to a CA to require and validate incoming client certificates.")
 
 	fTLSClient.StringP("tls-client-cert", "C", "", "path to the client certificate to authenticate against the minibridge backend.")
 	fTLSClient.StringP("tls-client-key", "K", "", "path to the key for the client certificate.")
 	fTLSClient.StringP("tls-client-key-pass", "P", "", "passphrase for the client certificate key.")
 	fTLSClient.String("tls-client-backend-ca", "", "path to a CA to validate the minibridge backend server certificates.")
-	fTLSClient.Bool("tls-client-insecure-skip-verify", false, "skip backend's server certificates validation. Do not do this.")
+	fTLSClient.Bool("tls-client-insecure-skip-verify", false, "skip backend's server certificates validation. INSECURE.")
 
 	fHealth.String("health-listen", ":8080", "listen address of the health server.")
 	fHealth.Bool("health-enable", false, "enables health server.")
@@ -45,7 +45,7 @@ func initSharedFlagSet() {
 	fPolicer.StringP("policer-url", "U", "", "URL of the policer to POST agent policing requests.")
 	fPolicer.StringP("policer-token", "T", "", "token to use to authenticate against the policer.")
 	fPolicer.String("policer-ca", "", "path to a CA to validate the policer server certificates.")
-	fPolicer.Bool("policer-insecure-skip-verify", false, "skip policer's server certificates validation. Do not do this.")
+	fPolicer.Bool("policer-insecure-skip-verify", false, "skip policer's server certificates validation. INSECURE.")
 
 	fJWTVerifier.StringP("auth-jwks-url", "J", "", "enables authentication and requires agent to send JWTs signed by the given JWKS.")
 	fJWTVerifier.String("auth-jwks-ca", "", "path to a CA to validate the JWKS server certificates.")
@@ -53,7 +53,7 @@ func initSharedFlagSet() {
 	fJWTVerifier.StringP("auth-jwt-required-issuer", "I", "", "when auth is enabled, sets the required JWTs issuer.")
 	fJWTVerifier.StringP("auth-jwt-required-audience", "A", "", "when auth is enabled, sets the required JWTs audience.")
 	fJWTVerifier.StringP("auth-jwt-principal-claim", "S", "", "when auth is enabled, sets the identity claim to use as the principal name to send to the policer.")
-	fJWTVerifier.Bool("auth-jwks-insecure-skip-verify", false, "skip JWKS's server certificate validation. Don't do this.")
+	fJWTVerifier.Bool("auth-jwks-insecure-skip-verify", false, "skip JWKS's server certificate validation. INSECURE.")
 
 	fCORS.String("cors-origin", "*", "sets the valid HTTP Origin for CORS responses.")
 

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -12,6 +12,7 @@ var (
 	fPolicer     = pflag.NewFlagSet("police", pflag.ExitOnError)
 	fJWTVerifier = pflag.NewFlagSet("jwtverifier", pflag.ExitOnError)
 	fCORS        = pflag.NewFlagSet("cors", pflag.ExitOnError)
+	fAgentAuth   = pflag.NewFlagSet("agentauth", pflag.ExitOnError)
 
 	initialized = false
 )
@@ -24,35 +25,37 @@ func initSharedFlagSet() {
 
 	initialized = true
 
-	fTLSServer.StringP("tls-server-cert", "c", "", "Path to the server certificate")
-	fTLSServer.StringP("tls-server-key", "k", "", "Path to the key for the certificate")
-	fTLSServer.StringP("tls-server-key-pass", "p", "", "Passphrase for the key")
-	fTLSServer.String("tls-server-client-ca", "", "Path to a CA to validate client connections")
+	fTLSServer.StringP("tls-server-cert", "c", "", "path to the server certificate for incoming HTTPS connections.")
+	fTLSServer.StringP("tls-server-key", "k", "", "path to the key for the server certificate.")
+	fTLSServer.StringP("tls-server-key-pass", "p", "", "passphrase for the server certificate key.")
+	fTLSServer.String("tls-server-client-ca", "", "path to a CA to validate incoming client certificate. When enabled clients must send a valid certificate.")
 
-	fTLSClient.StringP("tls-client-cert", "C", "", "Path to the client certificate")
-	fTLSClient.StringP("tls-client-key", "K", "", "Path to the key for the certificate")
-	fTLSClient.StringP("tls-client-key-pass", "P", "", "Passphrase for the key")
-	fTLSClient.String("tls-client-server-ca", "", "Path to a CA to validate server connections")
-	fTLSClient.Bool("tls-client-insecure-skip-verify", false, "If set, don't validate server's CA. Do not do this.")
+	fTLSClient.StringP("tls-client-cert", "C", "", "path to the client certificate to authenticate against the minibridge backend.")
+	fTLSClient.StringP("tls-client-key", "K", "", "path to the key for the client certificate.")
+	fTLSClient.StringP("tls-client-key-pass", "P", "", "passphrase for the client certificate key.")
+	fTLSClient.String("tls-client-backend-ca", "", "path to a CA to validate the minibridge backend server certificates.")
+	fTLSClient.Bool("tls-client-insecure-skip-verify", false, "skip backend's server certificates validation. Do not do this.")
 
-	fHealth.String("health-listen", ":8080", "Listen address of the health server")
-	fHealth.Bool("health-enable", false, "If set, start a health server for production deployments")
+	fHealth.String("health-listen", ":8080", "listen address of the health server.")
+	fHealth.Bool("health-enable", false, "enables health server.")
 
-	fProfiler.String("profiling-listen", ":6060", "Listen address of the health server")
-	fProfiler.Bool("profiling-enable", false, "If set, enable profiling server")
+	fProfiler.String("profiling-listen", ":6060", "listen address of the health server.")
+	fProfiler.Bool("profiling-enable", false, "enables profiling server.")
 
-	fPolicer.StringP("policer-url", "U", "", "Address of a Policer to send the traffic to for authentication and/or analysis")
-	fPolicer.StringP("policer-token", "T", "", "Token to use to authenticate against the Policer")
-	fPolicer.String("policer-ca", "", "CA to trust Policer server certificates")
-	fPolicer.String("policer-insecure-skip-verify", "", "Do not validate Policer CA. Do not do this")
+	fPolicer.StringP("policer-url", "U", "", "URL of the policer to POST agent policing requests.")
+	fPolicer.StringP("policer-token", "T", "", "token to use to authenticate against the policer.")
+	fPolicer.String("policer-ca", "", "path to a CA to validate the policer server certificates.")
+	fPolicer.Bool("policer-insecure-skip-verify", false, "skip policer's server certificates validation. Do not do this.")
 
-	fJWTVerifier.StringP("auth-jwks-url", "J", "", "If set, enables authentication and require JWT signed by a certificate in the given JWKS")
-	fJWTVerifier.String("auth-jwks-ca", "", "If set, use the certificates in the provided PEM to trust the remote JWKS")
-	fJWTVerifier.String("auth-jwt-cert", "", "If set, enables authentication and require JWT signed by the given certificate")
-	fJWTVerifier.StringP("auth-jwt-required-issuer", "I", "", "Sets the required issuer in the JWT when auth is enabled")
-	fJWTVerifier.StringP("auth-jwt-required-audience", "A", "", "Sets the required audience in the JWT when auth is enabled")
-	fJWTVerifier.StringP("auth-jwt-principal-claim", "S", "", "Sets the identity claim to use to extract the principal user name when auth is enabled")
-	fJWTVerifier.Bool("auth-jwks-insecure-skip-verify", false, "Don't validate the JWKS CA. Don't do this.")
+	fJWTVerifier.StringP("auth-jwks-url", "J", "", "enables authentication and requires agent to send JWTs signed by the given JWKS.")
+	fJWTVerifier.String("auth-jwks-ca", "", "path to a CA to validate the JWKS server certificates.")
+	fJWTVerifier.String("auth-jwt-cert", "", "enables authentication and requires agent to send JWTs signed by the given certificates.")
+	fJWTVerifier.StringP("auth-jwt-required-issuer", "I", "", "when auth is enabled, sets the required JWTs issuer.")
+	fJWTVerifier.StringP("auth-jwt-required-audience", "A", "", "when auth is enabled, sets the required JWTs audience.")
+	fJWTVerifier.StringP("auth-jwt-principal-claim", "S", "", "when auth is enabled, sets the identity claim to use as the principal name to send to the policer.")
+	fJWTVerifier.Bool("auth-jwks-insecure-skip-verify", false, "skip JWKS's server certificate validation. Don't do this.")
 
-	fCORS.String("cors-origin", "*", "Sets the valid HTTP Origin for CORS")
+	fCORS.String("cors-origin", "*", "sets the valid HTTP Origin for CORS responses.")
+
+	fAgentAuth.StringP("agent-token", "t", "", "JWT token to pass to the minibridge backend for agent identification.")
 }

--- a/internal/cmd/frontend.go
+++ b/internal/cmd/frontend.go
@@ -15,12 +15,12 @@ func init() {
 
 	initSharedFlagSet()
 
-	fFrontend.String("listen", "", "Listen address of the bridge for incoming connections. If this is unset, stdio is used.")
-	fFrontend.String("backend", "", "Address of the minibridge backend")
+	fFrontend.StringP("listen", "l", "", "Listen address of the bridge for incoming connections. If this is unset, stdio is used.")
+	fFrontend.StringP("backend", "A", "", "Address of the minibridge backend")
 	fFrontend.String("endpoint-messages", "/message", "When using HTTP, sets the endpoint to post messages")
 	fFrontend.String("endpoint-sse", "/sse", "When using HTTP, sets the endpoint to connect to the event stream")
-	fFrontend.String("agent-token", "", "The user token to pass inline to the minibridge backend to identify the agent that will be passed to the policer. You must use sse server by setting --listen and configure tls for communications with minibridghe backend")
-	fFrontend.Bool("agent-token-passthrough", false, "If set, the HTTP Authorization header of the incoming agent request will be forwarded as-is to the minibridge backend for agent identification")
+	fFrontend.StringP("agent-token", "t", "", "The user token to pass inline to the minibridge backend to identify the agent that will be passed to the policer. You must use sse server by setting --listen and configure tls for communications with minibridghe backend")
+	fFrontend.BoolP("agent-token-passthrough", "b", false, "If set, the HTTP Authorization header of the incoming agent request will be forwarded as-is to the minibridge backend for agent identification")
 
 	Frontend.Flags().AddFlagSet(fFrontend)
 	Frontend.Flags().AddFlagSet(fTLSClient)

--- a/internal/cmd/frontend.go
+++ b/internal/cmd/frontend.go
@@ -27,6 +27,7 @@ func init() {
 	Frontend.Flags().AddFlagSet(fTLSServer)
 	Frontend.Flags().AddFlagSet(fHealth)
 	Frontend.Flags().AddFlagSet(fProfiler)
+	Frontend.Flags().AddFlagSet(fCORS)
 }
 
 // Frontend is the cobra command to run the client.
@@ -58,6 +59,8 @@ var Frontend = &cobra.Command{
 			return err
 		}
 
+		corsPolicy := makeCORSPolicy()
+
 		startHelperServers(cmd.Context())
 
 		var proxy frontend.Frontend
@@ -85,6 +88,7 @@ var Frontend = &cobra.Command{
 				frontend.OptSSEMessageEndpoint(messageEndpoint),
 				frontend.OptSSEAgentToken(agentToken),
 				frontend.OptSSEAgentTokenPassthrough(agentTokenPassthrough),
+				frontend.OptSSECORSPolicy(corsPolicy),
 			)
 
 		} else {

--- a/internal/cmd/frontend.go
+++ b/internal/cmd/frontend.go
@@ -54,7 +54,7 @@ var Frontend = &cobra.Command{
 			)
 		}
 
-		backendTLSConfig, err := tlsConfigFromFlags(fTLSClient)
+		clientTLSConfig, err := tlsConfigFromFlags(fTLSClient)
 		if err != nil {
 			return err
 		}
@@ -67,14 +67,14 @@ var Frontend = &cobra.Command{
 
 		if listen != "" {
 
-			frontendTLSConfig, err := tlsConfigFromFlags(fTLSServer)
+			serverTLSConfig, err := tlsConfigFromFlags(fTLSServer)
 			if err != nil {
 				return err
 			}
 
 			slog.Info("Starting frontend",
 				"mode", "sse",
-				"tls", frontendTLSConfig != nil,
+				"tls", serverTLSConfig != nil,
 				"backend", backendURL,
 				"listen", listen,
 				"sse", sseEndpoint,
@@ -83,7 +83,7 @@ var Frontend = &cobra.Command{
 				"agent-token-passthrough", agentTokenPassthrough,
 			)
 
-			proxy = frontend.NewSSE(listen, backendURL, frontendTLSConfig, backendTLSConfig,
+			proxy = frontend.NewSSE(listen, backendURL, serverTLSConfig, clientTLSConfig,
 				frontend.OptSSEStreamEndpoint(sseEndpoint),
 				frontend.OptSSEMessageEndpoint(messageEndpoint),
 				frontend.OptSSEAgentToken(agentToken),
@@ -98,7 +98,7 @@ var Frontend = &cobra.Command{
 				"backend", backendURL,
 			)
 
-			proxy = frontend.NewStdio(backendURL, backendTLSConfig,
+			proxy = frontend.NewStdio(backendURL, clientTLSConfig,
 				frontend.OptStioAgentToken(agentToken),
 			)
 		}

--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -38,7 +38,7 @@ func tlsConfigFromFlags(flags *pflag.FlagSet) (*tls.Config, error) {
 		keyPath, _ = flags.GetString("tls-client-key")
 		keyPass, _ = flags.GetString("tls-client-key-pass")
 	}
-	serverCAPath, _ := flags.GetString("tls-client-server-ca")
+	serverCAPath, _ := flags.GetString("tls-client-backend-ca")
 
 	if flags.Name() == "tlsserver" {
 		certPath, _ = flags.GetString("tls-server-cert")
@@ -117,7 +117,7 @@ func jwtVerifierConfigFromFlags() jwtVerifierConfig {
 	cfg.principalClaim, _ = fJWTVerifier.GetString("auth-jwt-principal-claim")
 
 	if cfg.jwksURL != "" || cfg.jwtCertPath != "" {
-		slog.Info("JWT verifier configured",
+		slog.Info("Agent authentication configured",
 			"jwks-url", cfg.jwksURL,
 			"jwks-custom-ca", cfg.jwksCAPath != "",
 			"cert", cfg.jwtCertPath,

--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -262,3 +262,30 @@ func makeJWKS(ctx context.Context, cfg jwtVerifierConfig) (jwks *token.JWKS, err
 
 	return jwks, nil
 }
+
+func makeCORSPolicy() *bahamut.CORSPolicy {
+
+	origin, _ := fCORS.GetString("cors-origin")
+
+	if origin == "mirror" {
+		origin = bahamut.CORSOriginMirror
+	}
+
+	return &bahamut.CORSPolicy{
+		AllowOrigin:      origin,
+		AllowCredentials: true,
+		MaxAge:           1500,
+		AllowHeaders: []string{
+			"Authorization",
+			"Accept",
+			"Content-Type",
+			"Cache-Control",
+			"Cookie",
+		},
+		AllowMethods: []string{
+			"GET",
+			"POST",
+			"OPTIONS",
+		},
+	}
+}

--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -33,19 +33,18 @@ func tlsConfigFromFlags(flags *pflag.FlagSet) (*tls.Config, error) {
 	var certPath, keyPath, keyPass string
 
 	if flags.Name() == "tlsclient" {
-		certPath, _ = flags.GetString("client-cert")
-		keyPath, _ = flags.GetString("client-key")
-		keyPass, _ = flags.GetString("client-key-pass")
+		certPath, _ = flags.GetString("tls-client-cert")
+		keyPath, _ = flags.GetString("tls-client-key")
+		keyPass, _ = flags.GetString("tls-client-key-pass")
 	}
+	serverCAPath, _ := flags.GetString("tls-client-server-ca")
 
 	if flags.Name() == "tlsserver" {
-		certPath, _ = flags.GetString("cert")
-		keyPath, _ = flags.GetString("key")
-		keyPass, _ = flags.GetString("key-pass")
+		certPath, _ = flags.GetString("tls-server-cert")
+		keyPath, _ = flags.GetString("tls-server-key")
+		keyPass, _ = flags.GetString("tls-server-key-pass")
 	}
-
-	serverCAPath, _ := flags.GetString("server-ca")
-	clientCAPath, _ := flags.GetString("client-ca")
+	clientCAPath, _ := flags.GetString("tls-serverclient-ca")
 
 	if certPath != "" && keyPath != "" {
 		x509Cert, x509Key, err := tglib.ReadCertificatePEM(certPath, keyPath, keyPass)
@@ -108,13 +107,13 @@ func jwtVerifierConfigFromFlags() jwtVerifierConfig {
 
 	cfg := jwtVerifierConfig{}
 
-	cfg.jwksURL, _ = fJWTVerifier.GetString("jwks-url")
-	cfg.jwksCAPath, _ = fJWTVerifier.GetString("jwks-ca")
-	cfg.jwksSkipVerify, _ = fJWTVerifier.GetBool("jwks-insecure-skip-verify")
-	cfg.jwtCertPath, _ = fJWTVerifier.GetString("jwt-cert")
-	cfg.reqIss, _ = fJWTVerifier.GetString("jwt-required-issuer")
-	cfg.reqAud, _ = fJWTVerifier.GetString("jwt-required-audience")
-	cfg.principalClaim, _ = fJWTVerifier.GetString("jwt-principal-claim")
+	cfg.jwksURL, _ = fJWTVerifier.GetString("auth-jwks-url")
+	cfg.jwksCAPath, _ = fJWTVerifier.GetString("auth-jwks-ca")
+	cfg.jwksSkipVerify, _ = fJWTVerifier.GetBool("auth-jwks-insecure-skip-verify")
+	cfg.jwtCertPath, _ = fJWTVerifier.GetString("auth-jwt-cert")
+	cfg.reqIss, _ = fJWTVerifier.GetString("auth-jwt-required-issuer")
+	cfg.reqAud, _ = fJWTVerifier.GetString("auth-jwt-required-audience")
+	cfg.principalClaim, _ = fJWTVerifier.GetString("auth-jwt-principal-claim")
 
 	if cfg.jwksURL != "" || cfg.jwtCertPath != "" {
 		slog.Info("JWT verifier configured",

--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -20,10 +20,11 @@ func tlsConfigFromFlags(flags *pflag.FlagSet) (*tls.Config, error) {
 
 	var hasTLS bool
 
-	skipVerify, _ := flags.GetBool("insecure-skip-verify")
+	skipVerify, _ := flags.GetBool("tls-client-insecure-skip-verify")
 
 	if skipVerify {
 		slog.Warn("Certificate validation deactivated. Connection will not be secure")
+		hasTLS = true
 	}
 
 	tlsConfig := &tls.Config{
@@ -44,7 +45,7 @@ func tlsConfigFromFlags(flags *pflag.FlagSet) (*tls.Config, error) {
 		keyPath, _ = flags.GetString("tls-server-key")
 		keyPass, _ = flags.GetString("tls-server-key-pass")
 	}
-	clientCAPath, _ := flags.GetString("tls-serverclient-ca")
+	clientCAPath, _ := flags.GetString("tls-server-client-ca")
 
 	if certPath != "" && keyPath != "" {
 		x509Cert, x509Key, err := tglib.ReadCertificatePEM(certPath, keyPath, keyPass)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -15,8 +15,8 @@ func init() {
 
 	initSharedFlagSet()
 
-	Root.PersistentFlags().String("log-level", "info", "Set the log level")
-	Root.PersistentFlags().String("log-format", "console", "Set the log format")
+	Root.PersistentFlags().String("log-level", "info", "sets the log level.")
+	Root.PersistentFlags().String("log-format", "console", "sets the log format.")
 }
 
 var Root = &cobra.Command{

--- a/main.go
+++ b/main.go
@@ -16,10 +16,11 @@ func main() {
 		cmd.Backend,
 		cmd.Frontend,
 		cmd.AIO,
+		cmd.Completion,
 	)
 
 	if err := cmd.Root.Execute(); err != nil {
-		slog.Error("Minibridge exited with error", err)
+		slog.Error("Minibridge exited with error", "err", err)
 		os.Exit(1)
 	}
 }

--- a/pkgs/backend/options.go
+++ b/pkgs/backend/options.go
@@ -1,12 +1,17 @@
 package backend
 
 import (
+	"go.acuvity.ai/a3s/pkgs/token"
 	"go.acuvity.ai/minibridge/pkgs/policer"
 )
 
 type wsCfg struct {
-	policer    policer.Policer
-	dumpStderr bool
+	policer            policer.Policer
+	dumpStderr         bool
+	jwtJWKS            *token.JWKS
+	jwtRequiredIss     string
+	jwtRequiredAud     string
+	jwtPrincipalClaims string
 }
 
 func newWSCfg() wsCfg {
@@ -28,5 +33,15 @@ func OptWSPolicer(policer policer.Policer) OptWS {
 func OptWSDumpStderrOnError(dump bool) OptWS {
 	return func(cfg *wsCfg) {
 		cfg.dumpStderr = dump
+	}
+}
+
+// OptWSAuth configures the needed information to enable authentication.
+func OptWSAuth(jwks *token.JWKS, principalClaim string, requiredIssuer string, requiredAudience string) OptWS {
+	return func(cfg *wsCfg) {
+		cfg.jwtJWKS = jwks
+		cfg.jwtRequiredIss = requiredIssuer
+		cfg.jwtRequiredAud = requiredAudience
+		cfg.jwtPrincipalClaims = principalClaim
 	}
 }

--- a/pkgs/backend/options.go
+++ b/pkgs/backend/options.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"go.acuvity.ai/a3s/pkgs/token"
+	"go.acuvity.ai/bahamut"
 	"go.acuvity.ai/minibridge/pkgs/policer"
 )
 
@@ -12,6 +13,7 @@ type wsCfg struct {
 	jwtRequiredIss     string
 	jwtRequiredAud     string
 	jwtPrincipalClaims string
+	corsPolicy         *bahamut.CORSPolicy
 }
 
 func newWSCfg() wsCfg {
@@ -43,5 +45,13 @@ func OptWSAuth(jwks *token.JWKS, principalClaim string, requiredIssuer string, r
 		cfg.jwtRequiredIss = requiredIssuer
 		cfg.jwtRequiredAud = requiredAudience
 		cfg.jwtPrincipalClaims = principalClaim
+	}
+}
+
+// OptWSCORSPolicy sets the bahamut.CORSPolicy to use for
+// connection originating from a webrowser.
+func OptWSCORSPolicy(policy *bahamut.CORSPolicy) OptWS {
+	return func(cfg *wsCfg) {
+		cfg.corsPolicy = policy
 	}
 }

--- a/pkgs/backend/ws.go
+++ b/pkgs/backend/ws.go
@@ -104,6 +104,7 @@ func (p *wsBackend) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	stream, err := client.NewStdio(p.mcpServer).Start(req.Context())
 	if err != nil {
+		slog.Error("Unable to start mcp client", err)
 		http.Error(w, fmt.Sprintf("unable to start mcp client: %s", err), http.StatusInternalServerError)
 		return
 	}
@@ -111,6 +112,7 @@ func (p *wsBackend) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	select {
 	default:
 	case err := <-stream.Exit:
+		slog.Error("MCP server has exited", err)
 		http.Error(w, fmt.Sprintf("mcp server has exited: %s", err), http.StatusInternalServerError)
 		return
 	}
@@ -270,7 +272,7 @@ func authenticate(tokenString string, jwks *token.JWKS, reqIss string, reqAud st
 	user.Claims = idt.Identity
 	user.Name = pclaims[0]
 
-	slog.Info("Authenticated agent", "name", user.Name, "claims", user.Claims)
+	slog.Debug("Authenticated agent", "name", user.Name, "claims", user.Claims)
 
 	return user, nil
 }

--- a/pkgs/cors/cors.go
+++ b/pkgs/cors/cors.go
@@ -1,0 +1,31 @@
+package cors
+
+import (
+	"net/http"
+
+	"go.acuvity.ai/bahamut"
+)
+
+// HandleGenericHeaders injects generic security headers and CORS
+func HandleGenericHeaders(w http.ResponseWriter, req *http.Request, corsPolicy *bahamut.CORSPolicy) bool {
+
+	w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")
+	w.Header().Set("X-Frame-Options", "DENY")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-Xss-Protection", "1; mode=block")
+	w.Header().Set("Cache-Control", "private, no-transform")
+
+	if corsPolicy == nil {
+		return true
+	}
+
+	if req.Method == http.MethodOptions {
+		corsPolicy.Inject(w.Header(), req.Header.Get("Origin"), true)
+		w.WriteHeader(http.StatusNoContent)
+		return false
+	}
+
+	corsPolicy.Inject(w.Header(), req.Header.Get("Origin"), false)
+
+	return true
+}

--- a/pkgs/frontend/connect.go
+++ b/pkgs/frontend/connect.go
@@ -3,26 +3,65 @@ package frontend
 import (
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
 
 	"go.acuvity.ai/wsc"
 )
 
-func connectWS(ctx context.Context, backendURL string, tlsConfig *tls.Config) (wsc.Websocket, error) {
+func connectWS(ctx context.Context, backendURL string, tlsConfig *tls.Config, token string, authHeaders []string) (wsc.Websocket, error) {
 
-	session, resp, err := wsc.Connect(
-		ctx,
-		backendURL,
-		wsc.Config{
-			WriteChanSize: 64,
-			ReadChanSize:  16,
-			TLSConfig:     tlsConfig,
-		},
+	slog.Debug("New websocket connection",
+		"url", backendURL,
+		"using-token", token != "",
+		"using-headers", len(authHeaders) > 0,
+		"tls", tlsConfig != nil,
 	)
 
+	if (token != "" || len(authHeaders) > 0) && tlsConfig == nil {
+		slog.Warn("Security: connecting to a websocket with crendentials sent over the network in clear-text. Refused. Credentials have been stripped. Request will proceed and will likely fail.")
+	}
+
+	wsconfig := wsc.Config{
+		WriteChanSize: 64,
+		ReadChanSize:  16,
+		TLSConfig:     tlsConfig,
+	}
+
+	// TODO: SECURITY DO STRIP. This is for dev.
+
+	// if tlsConfig != nil {
+	if token != "" {
+		wsconfig.Headers = http.Header{
+			"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Appendf([]byte{}, "Bearer:%s", token)))},
+		}
+	} else if len(authHeaders) > 0 {
+		wsconfig.Headers = http.Header{"Authorization": authHeaders}
+	}
+	// }
+
+	session, resp, err := wsc.Connect(ctx, backendURL, wsconfig)
+
 	if err != nil {
-		return nil, fmt.Errorf("unable to connect to the websocket '%s': %w", backendURL, err)
+
+		var data []byte
+		var code int
+		status := "<empty>"
+
+		if resp != nil {
+			data, _ = io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+
+			code = resp.StatusCode
+			status = resp.Status
+		}
+
+		slog.Debug("WS connection failed", "code", code, "status", status, "data", string(data))
+
+		return nil, fmt.Errorf("unable to connect to the websocket. code: %d, status: %s: %w", code, status, err)
 	}
 
 	defer func() { _ = resp.Body.Close() }()

--- a/pkgs/frontend/connect.go
+++ b/pkgs/frontend/connect.go
@@ -31,17 +31,15 @@ func connectWS(ctx context.Context, backendURL string, tlsConfig *tls.Config, to
 		TLSConfig:     tlsConfig,
 	}
 
-	// TODO: SECURITY DO STRIP. This is for dev.
-
-	// if tlsConfig != nil {
-	if token != "" {
-		wsconfig.Headers = http.Header{
-			"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Appendf([]byte{}, "Bearer:%s", token)))},
+	if tlsConfig != nil {
+		if token != "" {
+			wsconfig.Headers = http.Header{
+				"Authorization": {"Basic " + base64.StdEncoding.EncodeToString(fmt.Appendf([]byte{}, "Bearer:%s", token))},
+			}
+		} else if len(authHeaders) > 0 {
+			wsconfig.Headers = http.Header{"Authorization": authHeaders}
 		}
-	} else if len(authHeaders) > 0 {
-		wsconfig.Headers = http.Header{"Authorization": authHeaders}
 	}
-	// }
 
 	session, resp, err := wsc.Connect(ctx, backendURL, wsconfig)
 

--- a/pkgs/frontend/hash.go
+++ b/pkgs/frontend/hash.go
@@ -1,0 +1,15 @@
+package frontend
+
+import (
+	"fmt"
+
+	"github.com/spaolacci/murmur3"
+)
+
+func hash(v string) uint64 {
+	return murmur3.Sum64([]byte(v)) & 0x7FFFFFFFFFFFFFFF // #nosec G115
+}
+
+func hashCreds(token string, authHeaders []string) uint64 {
+	return hash(fmt.Sprintf("%s-%v", token, authHeaders))
+}

--- a/pkgs/frontend/options.go
+++ b/pkgs/frontend/options.go
@@ -1,8 +1,10 @@
 package frontend
 
 type sseCfg struct {
-	sseEndpoint      string
-	messagesEndpoint string
+	sseEndpoint           string
+	messagesEndpoint      string
+	agentTokenPassthrough bool
+	agentToken            string
 }
 
 func newSSECfg() sseCfg {
@@ -33,8 +35,26 @@ func OptSSEMessageEndpoint(ep string) OptSSE {
 	}
 }
 
+// OptSSEAgentToken sets the token to send to the minibridge
+// backend in order to authenticate the agent sending a request though
+// the minibridge frontend.
+func OptSSEAgentToken(tokenString string) OptSSE {
+	return func(cfg *sseCfg) {
+		cfg.agentToken = tokenString
+	}
+}
+
+// OptSSEAgentTokenPassthrough decides if the HTTP request Authorization header
+// should be passed as-is to the minibridge backend.
+func OptSSEAgentTokenPassthrough(passthrough bool) OptSSE {
+	return func(cfg *sseCfg) {
+		cfg.agentTokenPassthrough = passthrough
+	}
+}
+
 type stdioCfg struct {
-	retry bool
+	retry      bool
+	agentToken string
 }
 
 func newStdioCfg() stdioCfg {
@@ -51,5 +71,13 @@ type OptStdio func(*stdioCfg)
 func OptStdioRetry(retry bool) OptStdio {
 	return func(cfg *stdioCfg) {
 		cfg.retry = retry
+	}
+}
+
+// OptStdioAgentToken sets the token to send to the minibridge
+// backend in order to authenticate the agent using the standard input.
+func OptStioAgentToken(tokenString string) OptStdio {
+	return func(cfg *stdioCfg) {
+		cfg.agentToken = tokenString
 	}
 }

--- a/pkgs/frontend/options.go
+++ b/pkgs/frontend/options.go
@@ -1,10 +1,13 @@
 package frontend
 
+import "go.acuvity.ai/bahamut"
+
 type sseCfg struct {
 	sseEndpoint           string
 	messagesEndpoint      string
 	agentTokenPassthrough bool
 	agentToken            string
+	corsPolicy            *bahamut.CORSPolicy
 }
 
 func newSSECfg() sseCfg {
@@ -23,6 +26,14 @@ type OptSSE func(*sseCfg)
 func OptSSEStreamEndpoint(ep string) OptSSE {
 	return func(cfg *sseCfg) {
 		cfg.sseEndpoint = ep
+	}
+}
+
+// OptSSECORSPolicy sets the bahamut.CORSPolicy to use for
+// connection originating from a webrowser.
+func OptSSECORSPolicy(policy *bahamut.CORSPolicy) OptSSE {
+	return func(cfg *sseCfg) {
+		cfg.corsPolicy = policy
 	}
 }
 

--- a/pkgs/frontend/sse.go
+++ b/pkgs/frontend/sse.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
+	"go.acuvity.ai/minibridge/pkgs/cors"
 	"go.acuvity.ai/wsc"
 )
 
@@ -143,7 +144,6 @@ func (p *sseFrontend) handleSSE(w http.ResponseWriter, req *http.Request) {
 	w.Header().Add("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Add("Connection", "keep-alive")
-	w.Header().Add("Set-Access-Control-Allow-Origin", "*")
 
 	w.WriteHeader(http.StatusOK)
 
@@ -241,6 +241,10 @@ func (p *sseFrontend) handleMessages(w http.ResponseWriter, req *http.Request) {
 // ServeHTTP is the main HTTP handler. If you decide to not start the built-in server
 // you can use this function directly into your own *http.Server.
 func (p *sseFrontend) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+
+	if !cors.HandleGenericHeaders(w, req, p.cfg.corsPolicy) {
+		return
+	}
 
 	switch req.URL.Path {
 

--- a/pkgs/frontend/sse.go
+++ b/pkgs/frontend/sse.go
@@ -149,7 +149,6 @@ func (p *sseFrontend) handleSSE(w http.ResponseWriter, req *http.Request) {
 
 	rc := http.NewResponseController(w)
 
-	// TODO: SECURITY parse url and stuff correctly here.
 	if _, err := fmt.Fprintf(w, "event: endpoint\ndata: %s?sessionId=%s\n\n", p.cfg.messagesEndpoint, sid); err != nil {
 		log.Error("Unable to send endpoint event", err)
 		return

--- a/pkgs/frontend/stdio.go
+++ b/pkgs/frontend/stdio.go
@@ -63,7 +63,7 @@ func (p *stdioFrontend) Start(ctx context.Context) error {
 		fmt.Sprintf("uid=%s", user.Uid),
 		fmt.Sprintf("username=%s", user.Username),
 		fmt.Sprintf("hostname=%s", host),
-		fmt.Sprintf("minibridge=stdio"),
+		"minibridge=stdio",
 	}
 
 	slog.Debug("Local machine user set", "user", p.user, "claims", p.claims)

--- a/pkgs/policer/interface.go
+++ b/pkgs/policer/interface.go
@@ -6,7 +6,12 @@ import (
 	api "go.acuvity.ai/api/apex"
 )
 
+type User struct {
+	Name   string
+	Claims []string
+}
+
 // A Policer is the interface of objects that can police request.
 type Policer interface {
-	Police(context.Context, api.PoliceRequestTypeValue, []byte) error
+	Police(context.Context, api.PoliceRequestTypeValue, []byte, User) error
 }

--- a/pkgs/policer/policer.go
+++ b/pkgs/policer/policer.go
@@ -36,20 +36,18 @@ func New(endpoint string, token string, tlsConfig *tls.Config) Policer {
 	}
 }
 
-func (p *policer) Police(ctx context.Context, rtype api.PoliceRequestTypeValue, data []byte) error {
+func (p *policer) Police(ctx context.Context, rtype api.PoliceRequestTypeValue, data []byte, user User) error {
 
 	sreq := api.NewPoliceRequest()
 	sreq.Type = rtype
 	sreq.Messages = []string{strings.TrimSpace(string(data))}
 
-	// TODO: add a way to let minibridge run the
-	// extraction to retrieve the name/claims from the
-	// request. This requires https://github.com/acuvity/acuvity/pull/1923
-	//
-	// sreq.User = &api.PoliceExternalUser{
-	// 	Name:   "joe",
-	// 	Claims: []string{"@org=acuvity.ai", "@scope=apps"},
-	// }
+	if user.Name != "" || len(user.Claims) > 0 {
+		sreq.User = &api.PoliceExternalUser{
+			Name:   user.Name,
+			Claims: user.Claims,
+		}
+	}
 
 	body, err := elemental.Encode(elemental.EncodingTypeJSON, sreq)
 	if err != nil {


### PR DESCRIPTION
This patch adds backend support for passing and policing an agent token coming from the frontend.

Minibridge frontend has the following new flags:

* --agent-token: The token to use to identify the agent.
* --agent-token-passthrough: In SSE, forward the Authorization header

Minibridge backend has the following new flags:

* --jwks-url: pass the URL of a JWKS
* --jwt-cert: pass a PEM files containing certs to validate the JWTs
* --jwt-required-issuer: set the mandatory issuer of the JWT
* --jwt-required-audience: set the mandatory audience of the JWT
* --jwt-principal-claim: set the claims to use to identify the agent