### PR TITLE
policer: revamp the api to make it easier to use

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.24.1
 
 require (
 	go.acuvity.ai/a3s v0.0.0-20250331211316-39bc5ec90f85
-	go.acuvity.ai/api v0.0.5
 	go.acuvity.ai/bahamut v0.0.0-20250226152621-d4dd109ed78a
 	go.acuvity.ai/elemental v0.0.0-20250226152430-c139902eba00
 	go.acuvity.ai/manipulate v0.0.0-20250331211103-13b505fe3e16 // indirect
@@ -44,7 +43,6 @@ require (
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,6 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
-github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 h1:DujepqpGd1hyOd7aW59XpK7Qymp8iy83xq74fLr21is=
@@ -275,8 +273,6 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.acuvity.ai/a3s v0.0.0-20250331211316-39bc5ec90f85 h1:nwOIqKUKNPOs/w9dQnJGSnLTefhqyYWi/pMJP9vmgKQ=
 go.acuvity.ai/a3s v0.0.0-20250331211316-39bc5ec90f85/go.mod h1:74v70zxHTVuh3j0q3KB22pO5U4xURsHA+5LFwA3Njok=
-go.acuvity.ai/api v0.0.5 h1:zE+MpvRbGgtiB3EhM+D+0dnLxmn0qjYxeDTqB6uHc/Y=
-go.acuvity.ai/api v0.0.5/go.mod h1:rkKys5n1cOBmQlPuQc9i8jkY4hE/rEecWxeLFu67KpY=
 go.acuvity.ai/bahamut v0.0.0-20250226152621-d4dd109ed78a h1:cx4KO0NBv/rWCVaBOmKoZ8u/UzWGz0Hmt72CNMi8KWs=
 go.acuvity.ai/bahamut v0.0.0-20250226152621-d4dd109ed78a/go.mod h1:btpwoWi/nDsuM83Ev5gU/TCBS/WV8Gt9AU0TZSWeffA=
 go.acuvity.ai/elemental v0.0.0-20250226152430-c139902eba00 h1:juUUn54tyhwvwb08RroIYM/eoCXa3ET109Cf7HLmJ/I=

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -5,14 +5,13 @@ import (
 )
 
 var (
-	fTLSClient   = pflag.NewFlagSet("tlsclient", pflag.ExitOnError)
-	fTLSServer   = pflag.NewFlagSet("tlsserver", pflag.ExitOnError)
-	fProfiler    = pflag.NewFlagSet("profile", pflag.ExitOnError)
-	fHealth      = pflag.NewFlagSet("health", pflag.ExitOnError)
-	fPolicer     = pflag.NewFlagSet("police", pflag.ExitOnError)
-	fJWTVerifier = pflag.NewFlagSet("jwtverifier", pflag.ExitOnError)
-	fCORS        = pflag.NewFlagSet("cors", pflag.ExitOnError)
-	fAgentAuth   = pflag.NewFlagSet("agentauth", pflag.ExitOnError)
+	fTLSClient = pflag.NewFlagSet("tlsclient", pflag.ExitOnError)
+	fTLSServer = pflag.NewFlagSet("tlsserver", pflag.ExitOnError)
+	fProfiler  = pflag.NewFlagSet("profile", pflag.ExitOnError)
+	fHealth    = pflag.NewFlagSet("health", pflag.ExitOnError)
+	fPolicer   = pflag.NewFlagSet("police", pflag.ExitOnError)
+	fCORS      = pflag.NewFlagSet("cors", pflag.ExitOnError)
+	fAgentAuth = pflag.NewFlagSet("agentauth", pflag.ExitOnError)
 
 	initialized = false
 )
@@ -46,14 +45,6 @@ func initSharedFlagSet() {
 	fPolicer.StringP("policer-token", "T", "", "token to use to authenticate against the policer.")
 	fPolicer.String("policer-ca", "", "path to a CA to validate the policer server certificates.")
 	fPolicer.Bool("policer-insecure-skip-verify", false, "skip policer's server certificates validation. INSECURE.")
-
-	fJWTVerifier.StringP("auth-jwks-url", "J", "", "enables authentication and requires agent to send JWTs signed by the given JWKS.")
-	fJWTVerifier.String("auth-jwks-ca", "", "path to a CA to validate the JWKS server certificates.")
-	fJWTVerifier.String("auth-jwt-cert", "", "enables authentication and requires agent to send JWTs signed by the given certificates.")
-	fJWTVerifier.StringP("auth-jwt-required-issuer", "I", "", "when auth is enabled, sets the required JWTs issuer.")
-	fJWTVerifier.StringP("auth-jwt-required-audience", "A", "", "when auth is enabled, sets the required JWTs audience.")
-	fJWTVerifier.StringP("auth-jwt-principal-claim", "S", "", "when auth is enabled, sets the identity claim to use as the principal name to send to the policer.")
-	fJWTVerifier.Bool("auth-jwks-insecure-skip-verify", false, "skip JWKS's server certificate validation. INSECURE.")
 
 	fCORS.String("cors-origin", "*", "sets the valid HTTP Origin for CORS responses.")
 

--- a/internal/cmd/frontend.go
+++ b/internal/cmd/frontend.go
@@ -83,7 +83,7 @@ var Frontend = &cobra.Command{
 				"messages", messageEndpoint,
 				"mode", "sse",
 				"server-tls", serverTLSConfig != nil,
-				"server-mtls", serverTLSConfig.ClientAuth.String(),
+				"server-mtls", mtlsMode(serverTLSConfig),
 				"client-tls", clientTLSConfig != nil,
 				"listen", listen,
 			)

--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -6,11 +6,9 @@ import (
 	"crypto/x509"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"os"
 
 	"github.com/spf13/pflag"
-	"go.acuvity.ai/a3s/pkgs/token"
 	"go.acuvity.ai/bahamut"
 	"go.acuvity.ai/minibridge/pkgs/policer"
 	"go.acuvity.ai/tg/tglib"
@@ -94,48 +92,6 @@ func tlsConfigFromFlags(flags *pflag.FlagSet) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-type jwtVerifierConfig struct {
-	jwksURL        string
-	jwksCAPath     string
-	jwksSkipVerify bool
-	jwtCertPath    string
-	reqIss         string
-	reqAud         string
-	principalClaim string
-}
-
-func jwtVerifierConfigFromFlags() jwtVerifierConfig {
-
-	cfg := jwtVerifierConfig{}
-
-	cfg.jwksURL, _ = fJWTVerifier.GetString("auth-jwks-url")
-	cfg.jwksCAPath, _ = fJWTVerifier.GetString("auth-jwks-ca")
-	cfg.jwksSkipVerify, _ = fJWTVerifier.GetBool("auth-jwks-insecure-skip-verify")
-	cfg.jwtCertPath, _ = fJWTVerifier.GetString("auth-jwt-cert")
-	cfg.reqIss, _ = fJWTVerifier.GetString("auth-jwt-required-issuer")
-	cfg.reqAud, _ = fJWTVerifier.GetString("auth-jwt-required-audience")
-	cfg.principalClaim, _ = fJWTVerifier.GetString("auth-jwt-principal-claim")
-
-	if cfg.jwksURL != "" || cfg.jwtCertPath != "" {
-		slog.Info("Agent authentication configured",
-			"jwks-url", cfg.jwksURL,
-			"jwks-custom-ca", cfg.jwksCAPath != "",
-			"cert", cfg.jwtCertPath,
-			"req-iss", cfg.reqIss,
-			"req-aud", cfg.reqAud,
-			"principal-claim", cfg.principalClaim,
-		)
-	} else {
-		slog.Info("No JWT verifier configured")
-	}
-
-	if cfg.jwksSkipVerify {
-		slog.Warn("Security: JWT verifier will trust any jwks server ca. This is VERY insecure.")
-	}
-
-	return cfg
-}
-
 func startHelperServers(ctx context.Context) bahamut.MetricsManager { // nolint: unparam
 
 	healthEnabled, _ := fHealth.GetBool("health-enable")
@@ -201,69 +157,6 @@ func makePolicer() (policer.Policer, error) {
 	return policer.New(policerURL, policerToken, tlsConfig), nil
 }
 
-func makeJWKS(ctx context.Context, cfg jwtVerifierConfig) (jwks *token.JWKS, err error) {
-
-	if cfg.jwtCertPath == "" && cfg.jwksURL == "" {
-		return nil, nil
-	}
-
-	switch {
-
-	case cfg.jwksURL != "":
-
-		var transport http.RoundTripper
-
-		if cfg.jwksSkipVerify {
-
-			slog.Warn("JWKS TLS Certificate verification disabled. This is highly insecure.")
-
-			transport = &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
-			}
-
-		} else if cfg.jwksCAPath != "" {
-
-			caBytes, err := os.ReadFile(cfg.jwksCAPath)
-			if err != nil {
-				return nil, fmt.Errorf("unable to load jwks CA from '%s': %w", cfg.jwksCAPath, err)
-			}
-
-			pool := x509.NewCertPool()
-			if !pool.AppendCertsFromPEM(caBytes) {
-				return nil, fmt.Errorf("unable to append ca to jwks client pool")
-			}
-
-			transport = &http.Transport{
-				TLSClientConfig: &tls.Config{
-					RootCAs: pool,
-				},
-			}
-		}
-
-		if jwks, err = token.NewRemoteJWKS(ctx, &http.Client{Transport: transport}, cfg.jwksURL); err != nil {
-			return nil, fmt.Errorf("unable to load remote jwks from '%s': %w", cfg.jwksURL, err)
-		}
-
-	case cfg.jwtCertPath != "":
-
-		certs, err := tglib.ParseCertificatePEMs(cfg.jwtCertPath)
-		if err != nil {
-			return nil, fmt.Errorf("unable parse jwt certificate from '%s': %w", cfg.jwtCertPath, err)
-		}
-
-		jwks = token.NewJWKS()
-		for _, c := range certs {
-			if err := jwks.Append(c); err != nil {
-				return nil, fmt.Errorf("unable to append certificate '%s' to JWKS: %w", cfg.jwtCertPath, err)
-			}
-		}
-	}
-
-	return jwks, nil
-}
-
 func makeCORSPolicy() *bahamut.CORSPolicy {
 
 	origin, _ := fCORS.GetString("cors-origin")
@@ -289,4 +182,13 @@ func makeCORSPolicy() *bahamut.CORSPolicy {
 			"OPTIONS",
 		},
 	}
+}
+
+func mtlsMode(tlsCfg *tls.Config) string {
+
+	if tlsCfg == nil {
+		return "NoClientCert"
+	}
+
+	return tlsCfg.ClientAuth.String()
 }

--- a/pkgs/backend/options.go
+++ b/pkgs/backend/options.go
@@ -1,19 +1,14 @@
 package backend
 
 import (
-	"go.acuvity.ai/a3s/pkgs/token"
 	"go.acuvity.ai/bahamut"
 	"go.acuvity.ai/minibridge/pkgs/policer"
 )
 
 type wsCfg struct {
-	policer            policer.Policer
-	dumpStderr         bool
-	jwtJWKS            *token.JWKS
-	jwtRequiredIss     string
-	jwtRequiredAud     string
-	jwtPrincipalClaims string
-	corsPolicy         *bahamut.CORSPolicy
+	policer    policer.Policer
+	dumpStderr bool
+	corsPolicy *bahamut.CORSPolicy
 }
 
 func newWSCfg() wsCfg {
@@ -35,16 +30,6 @@ func OptWSPolicer(policer policer.Policer) OptWS {
 func OptWSDumpStderrOnError(dump bool) OptWS {
 	return func(cfg *wsCfg) {
 		cfg.dumpStderr = dump
-	}
-}
-
-// OptWSAuth configures the needed information to enable authentication.
-func OptWSAuth(jwks *token.JWKS, principalClaim string, requiredIssuer string, requiredAudience string) OptWS {
-	return func(cfg *wsCfg) {
-		cfg.jwtJWKS = jwks
-		cfg.jwtRequiredIss = requiredIssuer
-		cfg.jwtRequiredAud = requiredAudience
-		cfg.jwtPrincipalClaims = principalClaim
 	}
 }
 

--- a/pkgs/frontend/sse.go
+++ b/pkgs/frontend/sse.go
@@ -185,6 +185,7 @@ func (p *sseFrontend) handleSSE(w http.ResponseWriter, req *http.Request) {
 				log.Error("Unable to write event", err)
 				continue
 			}
+
 			if err := rc.Flush(); err != nil {
 				log.Error("Unable to flush remote event", err)
 				continue

--- a/pkgs/policer/api/request.go
+++ b/pkgs/policer/api/request.go
@@ -1,0 +1,42 @@
+package api
+
+// RequestType type of request to the policer.
+type RequestType string
+
+// Various values of RequestType
+var (
+	Input  RequestType = "input"
+	Output RequestType = "output"
+)
+
+// An MPCError represents an inline MPC error.
+type MCPError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message,omitempty"`
+	Data    any    `json:"data,omitempty"`
+}
+
+// MPCCall represents the inline MPC request.
+type MCPCall struct {
+	JSONRPC string         `json:"jsonrpc"`
+	ID      any            `json:"id"`
+	Method  string         `json:"method,omitempty"`
+	Params  map[string]any `json:"params,omitempty"`
+	Result  map[string]any `json:"result,omitempty"`
+	Error   *MCPError      `json:"error,omitempty"`
+}
+
+// A Request represents the data sent to the Policer
+type Request struct {
+
+	// Token is the agent token that as been received by the backend.
+	Token string `json:"token"`
+
+	// Type of the request. Input will be set for request from the agent
+	// and Output will be set for replies from the MPC server.
+	Type RequestType `json:"type"`
+
+	// MPC embeds the full MPC call, either request or response,
+	// based on the Type.
+	MCP MCPCall `json:"mcp,omitzero"`
+}

--- a/pkgs/policer/api/response.go
+++ b/pkgs/policer/api/response.go
@@ -1,0 +1,29 @@
+package api
+
+// Decision represents the Policer decision.
+type Decision string
+
+// Various values for Decision.
+var (
+	// DecisionAllow represents the Policer allowing the call.
+	DecisionAllow Decision = "allow"
+
+	// DecisionDeny represents the Policer refusing the call
+	// because of an issue in the content of the MCP call.
+	DecisionDeny Decision = "deny"
+
+	// DecisionForbidden represents the Policer refusing the call
+	// because of an authentication error.
+	DecisionForbidden Decision = "forbidden"
+)
+
+// A Response is returned by the Policer.
+type Response struct {
+
+	// Decision of the Policer
+	Decision Decision `json:"decision"`
+
+	// Reasons for the decision. They are only set
+	// when the Decision is now DecisionAllow.
+	Reasons []string `json:"reasons,omitzero"`
+}

--- a/pkgs/policer/interface.go
+++ b/pkgs/policer/interface.go
@@ -3,15 +3,10 @@ package policer
 import (
 	"context"
 
-	api "go.acuvity.ai/api/apex"
+	"go.acuvity.ai/minibridge/pkgs/policer/api"
 )
-
-type User struct {
-	Name   string
-	Claims []string
-}
 
 // A Policer is the interface of objects that can police request.
 type Policer interface {
-	Police(context.Context, api.PoliceRequestTypeValue, []byte, User) error
+	Police(context.Context, api.Request) error
 }

--- a/policers/example/policer.py
+++ b/policers/example/policer.py
@@ -1,0 +1,39 @@
+#!/bin/python
+
+import json
+from flask import Flask, request
+
+app = Flask(__name__)
+
+@app.route("/police", methods=['POST'])
+def police():
+    req = request.get_json()
+
+
+    print("---")
+    print("Type: %s" % req['type'])
+    print("Headers: %s" % request.headers)
+    print(json.dumps(req, sort_keys=True, indent=4))
+
+    # If there is no agent token, we refuse the call.
+    # Of course, this is an example. IRL, you will validate that token.
+    if req['token'] == "":
+        print("REJECTED: no token")
+        return json.dumps({
+            "decision": "deny",
+            "reasons": ["you have not passed any token"],
+        })
+
+    # As an example, we forbid user to use list_directory tools. Why? why not?
+    if req['type'] == 'input':
+        mcp = req['mcp']
+        if mcp['method'] == "tools/call" and mcp['params']['name'] == "list_directory":
+            return json.dumps({
+                "decision": "deny",
+                "reasons": ["you cannot list directories"],
+            })
+
+    # otherwise we allow everything
+    return json.dumps({"decision": "allow"})
+
+app.run(port=5000)


### PR DESCRIPTION
This patch adapts the API to make it more MCP oriented and removes the JWT part. It happens that it would be well more served by a Policer so it can handle everything regarding authn/authz versus having a split brain issue with JWT validation on one side and authz on a policer.

Also adds an example policer.