### PR TITLE
scan: add prompts to sbom and update dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ SBOM (Software Bill of Materials) generation and real-time validation.
   * [Generate SBOM](#generate-sbom)
   * [Check SBOM Offline](#check-sbom-offline)
   * [Check SBOM Online](#check-sbom-online)
-  * [List Tools](#list-tools)
+  * [Dump everything](#dump-everything)
 * [Policer](#policer)
   * [Policer API](#policer-api)
     * [Police Request](#police-request)
@@ -235,7 +235,7 @@ To generate a SBOM file:
 This will create `server.sbom` that contains all the hashes of the relevant
 parts.
 
-> NOTE: For now, only tools are part of the SBOM.
+> NOTE: For now, only tools and prompts are part of the SBOM.
 
 ### Check SBOM Offline
 
@@ -255,13 +255,14 @@ To start Minibridge backend with live SBOM validation:
 
     minibridge backend -l :8000 --sbom server.sbom -- npx @modelcontextprotocol/server-everything
 
-### List Tools
+### Dump everything
 
-Dump all the tools of a particular MCP Server.
+Dump all the tools, prompts, resources and resource templates of a particular
+MCP Server.
 
 For example:
 
-    minibridge scan tools -- npx @modelcontextprotocol/server-everything
+    minibridge scan dump -- npx @modelcontextprotocol/server-everything
 
 ## Policer
 

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 		if _, ok := slog.Default().Handler().(*slog.JSONHandler); ok {
 			slog.Error("Minibridge exited with error", "err", err)
 		} else {
-			fmt.Fprintf(os.Stderr, "error: %s", err.Error())
+			fmt.Fprintf(os.Stderr, "error: %s\n", err.Error())
 		}
 		os.Exit(1)
 	}

--- a/pkgs/policer/api/mcp.go
+++ b/pkgs/policer/api/mcp.go
@@ -58,21 +58,40 @@ func NewInitCall(proto ProtocolVersion) MCPCall {
 	}
 }
 
-type Tools []*Tool
-
+type Tools []Tool
 type Tool struct {
 	Name        string         `json:"name"`
 	Description string         `json:"description,omitempty"`
 	InputSchema map[string]any `json:"InputSchema,omitempty"`
 }
 
-type Resources []*Resource
-
+type Resources []Resource
 type Resource struct {
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
 	MimeType    string `json:"mimeType,omitempty"`
 	Text        string `json:"text,omitempty"`
-	Blob        []byte `json:"blob,omitempty"`
+	Blob        string `json:"blob,omitempty"`
 	URI         string `json:"uri,omitempty"`
+}
+
+type ResourceTemplates []ResourceTemplate
+type ResourceTemplate struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	URITemplate string `json:"uriTemplate,omitempty"`
+}
+
+type Prompts []*Prompt
+type Prompt struct {
+	Name        string          `json:"name,omitempty"`
+	Description string          `json:"description,omitempty"`
+	Arguments   PromptArguments `json:"arguments,omitempty"`
+}
+
+type PromptArguments []PromptArgument
+type PromptArgument struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
 }

--- a/pkgs/utils/scan.go
+++ b/pkgs/utils/scan.go
@@ -4,50 +4,42 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"os"
 
 	"github.com/mitchellh/mapstructure"
-	"go.acuvity.ai/elemental"
 	"go.acuvity.ai/minibridge/pkgs/client"
 	"go.acuvity.ai/minibridge/pkgs/policer/api"
 )
 
-func LoadSBOM(path string) (sbom SBOM, err error) {
-
-	data, err := os.ReadFile(path) // #nosec: G304
-	if err != nil {
-		return sbom, fmt.Errorf("unable to load sbom file at '%s': %w", path, err)
-	}
-
-	if err := elemental.Decode(elemental.EncodingTypeJSON, data, &sbom); err != nil {
-		return sbom, fmt.Errorf("unable to decode content of sbom file: %w", err)
-	}
-
-	return sbom, nil
+type Dump struct {
+	Tools             api.Tools             `json:"tools,omitempty"`
+	Resources         api.Resources         `json:"resources,omitempty"`
+	ResourceTemplates api.ResourceTemplates `json:"resourceTemplates,omitempty"`
+	Prompts           api.Prompts           `json:"prompts,omitempty"`
 }
 
-// DumpTools dumps all the tools available from the given client.MCPStream.
-func DumpTools(ctx context.Context, stream *client.MCPStream) (api.Tools, error) {
+// Dump dumps all the all available tools/resource/prompts from the given client.MCPStream.
+func DumpAll(ctx context.Context, stream *client.MCPStream) (Dump, error) {
 
 	if _, err := stream.Roundtrip(ctx, api.NewInitCall(api.ProtocolVersion20250326)); err != nil {
-		return nil, fmt.Errorf("unable to send mcp request: %w", err)
+		return Dump{}, fmt.Errorf("unable to send mcp request: %w", err)
 	}
 
 	notif := api.NewMCPCall(-1)
 	notif.Method = "notifications/initialized"
 	if err := stream.Send(notif); err != nil {
-		return nil, fmt.Errorf("unable to send mcp inititlized notif: %w", err)
+		return Dump{}, fmt.Errorf("unable to send mcp inititlized notif: %w", err)
 	}
 
-	call := api.NewMCPCall(1)
-	call.Method = "tools/list"
+	dump := Dump{}
 
-	resps, err := stream.PRoundtrip(ctx, call)
+	// Tools
+
+	toolsReq := api.NewMCPCall(1)
+	toolsReq.Method = "tools/list"
+	resps, err := stream.PRoundtrip(ctx, toolsReq)
 	if err != nil {
-		return nil, fmt.Errorf("unable to send mcp request: %w", err)
+		return Dump{}, fmt.Errorf("unable to send tools/list mcp request: %w", err)
 	}
-
-	tools := api.Tools{}
 
 	for _, resp := range resps {
 
@@ -55,19 +47,84 @@ func DumpTools(ctx context.Context, stream *client.MCPStream) (api.Tools, error)
 			continue
 		}
 
-		ltools := api.Tools{}
-		if err := mapstructure.Decode(resp.Result["tools"], &ltools); err != nil {
-			return nil, fmt.Errorf("unable to convert to tools: %w", err)
+		tools := api.Tools{}
+		if err := mapstructure.Decode(resp.Result["tools"], &tools); err != nil {
+			return Dump{}, fmt.Errorf("unable to convert to tools: %w", err)
 		}
 
-		tools = append(tools, ltools...)
+		dump.Tools = append(dump.Tools, tools...)
 	}
 
-	return tools, nil
+	// Resources
+	resourcesReq := api.NewMCPCall(2)
+	resourcesReq.Method = "resources/list"
+	resps, err = stream.PRoundtrip(ctx, resourcesReq)
+	if err != nil {
+		return Dump{}, fmt.Errorf("unable to send resources/list mcp request: %w", err)
+	}
+
+	for _, resp := range resps {
+
+		if _, ok := resp.Result["resources"]; !ok {
+			continue
+		}
+
+		resources := api.Resources{}
+		if err := mapstructure.Decode(resp.Result["resources"], &resources); err != nil {
+			return Dump{}, fmt.Errorf("unable to convert to resources: %w", err)
+		}
+
+		dump.Resources = append(dump.Resources, resources...)
+	}
+
+	// Resources Templates
+	resourcesTemplateReq := api.NewMCPCall(3)
+	resourcesTemplateReq.Method = "resources/templates/list"
+	resps, err = stream.PRoundtrip(ctx, resourcesTemplateReq)
+	if err != nil {
+		return Dump{}, fmt.Errorf("unable to send resources/templates/list mcp request: %w", err)
+	}
+
+	for _, resp := range resps {
+
+		if _, ok := resp.Result["resourceTemplates"]; !ok {
+			continue
+		}
+
+		resourceTemplates := api.ResourceTemplates{}
+		if err := mapstructure.Decode(resp.Result["resourceTemplates"], &resourceTemplates); err != nil {
+			return Dump{}, fmt.Errorf("unable to convert to resources templates: %w", err)
+		}
+
+		dump.ResourceTemplates = append(dump.ResourceTemplates, resourceTemplates...)
+	}
+
+	// Prompts
+	promptsReq := api.NewMCPCall(4)
+	promptsReq.Method = "prompts/list"
+	resps, err = stream.PRoundtrip(ctx, promptsReq)
+	if err != nil {
+		return Dump{}, fmt.Errorf("unable to send prompts/list mcp request: %w", err)
+	}
+
+	for _, resp := range resps {
+
+		if _, ok := resp.Result["prompts"]; !ok {
+			continue
+		}
+
+		prompts := api.Prompts{}
+		if err := mapstructure.Decode(resp.Result["prompts"], &prompts); err != nil {
+			return Dump{}, fmt.Errorf("unable to convert to prompts: %w", err)
+		}
+
+		dump.Prompts = append(dump.Prompts, prompts...)
+	}
+
+	return dump, nil
 }
 
-// HashTools will generate a hashfile of all the tools available in the given
-// *client.MCPStream.
+// HashTools will generate Hashes for the given api.Tools
 func HashTools(tools api.Tools) (Hashes, error) {
 
 	hashes := []Hash{}
@@ -99,6 +156,31 @@ func HashTools(tools api.Tools) (Hashes, error) {
 					Hash: fmt.Sprintf("%x", sha256.Sum256([]byte(pdesc))),
 				})
 			}
+		}
+
+		hashes = append(hashes, h)
+	}
+
+	return hashes, nil
+}
+
+// HashPrompt generate Hashes for the given api.Prompt
+func HashPrompts(prompts api.Prompts) (Hashes, error) {
+
+	hashes := []Hash{}
+	for _, tool := range prompts {
+
+		h := Hash{
+			Name: tool.Name,
+			Hash: fmt.Sprintf("%x", sha256.Sum256([]byte(tool.Description))),
+		}
+
+		for _, p := range tool.Arguments {
+
+			h.Params = append(h.Params, Hash{
+				Name: p.Name,
+				Hash: fmt.Sprintf("%x", sha256.Sum256([]byte(p.Description))),
+			})
 		}
 
 		hashes = append(hashes, h)


### PR DESCRIPTION
`scan dump` replaces `scan tools`. It will dump everything:

- tools
- resources
- resource templates
- prompts

`scan sbom` also include prompts into the generated sbom.