### PR TITLE
scan: added a default timeout and exclude flag

### DIFF
--- a/pkgs/backend/client/client_test.go
+++ b/pkgs/backend/client/client_test.go
@@ -70,7 +70,7 @@ func TestClient(t *testing.T) {
 
 		srv := MCPServer{
 			Command: "bash",
-			Args:    []string{"-c", "sleep 1 && ls /this/does/not/exist"},
+			Args:    []string{"-c", "sleep 1 && exit 1"},
 		}
 		cl := NewStdio(srv)
 
@@ -84,9 +84,8 @@ func TestClient(t *testing.T) {
 
 		err = <-stream.Exit
 		So(err, ShouldNotBeNil)
-		So(err.Error(), ShouldEqual, "exit status 2")
+		So(err.Error(), ShouldEqual, "exit status 1")
 
-		So(string(<-stream.Stderr), ShouldEqual, "ls: cannot access '/this/does/not/exist': No such file or directory")
 	})
 
 	Convey("Given I have a client that writes a file", t, func() {

--- a/pkgs/backend/client/mcp_test.go
+++ b/pkgs/backend/client/mcp_test.go
@@ -42,7 +42,7 @@ func TestMCPStream(t *testing.T) {
 		}
 
 		Convey("I send a call, it should reach stdin", func() {
-			err := stream.Send(api.NewMCPCall(42))
+			err := stream.Send(context.Background(), api.NewMCPCall(42))
 			So(err, ShouldBeNil)
 			So(string(<-stdin), ShouldEqual, `{"id":42,"jsonrpc":"2.0"}`)
 		})

--- a/pkgs/scan/sbom.go
+++ b/pkgs/scan/sbom.go
@@ -7,6 +7,14 @@ import (
 	"go.acuvity.ai/elemental"
 )
 
+// Exclusions contains the resources we
+// want to exclude from scan
+type Exclusions struct {
+	Prompts   bool
+	Resources bool
+	Tools     bool
+}
+
 // SBOM contains a list of hashes for hashable
 // resources.
 type SBOM struct {

--- a/pkgs/scan/scan.go
+++ b/pkgs/scan/scan.go
@@ -29,7 +29,7 @@ func DumpAll(ctx context.Context, stream *client.MCPStream) (Dump, error) {
 
 	notif := api.NewMCPCall("")
 	notif.Method = "notifications/initialized"
-	if err := stream.Send(notif); err != nil {
+	if err := stream.Send(ctx, notif); err != nil {
 		return Dump{}, fmt.Errorf("unable to send mcp inititlized notif: %w", err)
 	}
 


### PR DESCRIPTION
If the server don’t reply for multiple reasons this or avoid scan to block forever. 

Added a way to exclude resources from scan dump as some server uses resources dynamically like docker. One might want to exclude them. 