### PR TITLE
policer/rego: set controlled env var to runtime

### DIFF
--- a/examples/policer-rego/basic-auth.rego
+++ b/examples/policer-rego/basic-auth.rego
@@ -1,0 +1,20 @@
+# This policy enforces a deny‐all default and, if the BASIC_AUTH env var is set,
+# compares it to input.agent.password passed by the client as basic Authentication headers
+# The request with the reason “invalid credentials” when they don’t match.
+# To set BASIC_AUTH run export REGO_POLICY_RUNTIME_BASIC_AUTH="s3cr3t"
+package main
+
+import rego.v1
+
+secret := opa.runtime().env.BASIC_AUTH
+
+reasons contains "access denied" if {
+	secret != ""
+	input.agent.password != secret
+}
+
+default allow := false
+
+allow if {
+	count(reasons) == 0
+}


### PR DESCRIPTION
This allow to pass some runtime information from the policy.

This can be useful, to have generic policies.

ex:
- check auth against a passed "secret" passphrase
- allow granular policy within one file

ex:

```
export REGO_POLICY_RUNTIME_BASIC_AUTH_SECRET=secret0
```

```rego
package main

import rego.v1

default allow := false

env := opa.runtime().env

reasons contains "invalid credentials" if {
	env.BASIC_AUTH_SECRET != ""
	input.agent.password != env.BASIC_AUTH_SECRET
}
```