### PR TITLE
backend: add an SSE client

### DIFF
--- a/cli/internal/cmd/backend.go
+++ b/cli/internal/cmd/backend.go
@@ -68,7 +68,10 @@ var Backend = &cobra.Command{
 
 		corsPolicy := makeCORSPolicy()
 
-		clientOpts := makeMCPClientOptions()
+		mcpClient, err := makeMCPClient(args)
+		if err != nil {
+			return fmt.Errorf("unable to create MCP client: %w", err)
+		}
 
 		mm := startHealthServer(cmd.Context())
 
@@ -88,13 +91,12 @@ var Backend = &cobra.Command{
 			"listen", listen,
 		)
 
-		proxy := backend.NewWebSocket(listen, backendTLSConfig, mcpServer,
+		proxy := backend.NewWebSocket(listen, backendTLSConfig, mcpClient,
 			backend.OptPolicer(policer),
 			backend.OptPolicerEnforce(penforce),
 			backend.OptDumpStderrOnError(viper.GetString("log-format") != "json"),
 			backend.OptCORSPolicy(corsPolicy),
 			backend.OptSBOM(sbom),
-			backend.OptClientOptions(clientOpts...),
 			backend.OptMetricsManager(mm),
 			backend.OptTracer(tracer),
 		)

--- a/cli/internal/cmd/flags.go
+++ b/cli/internal/cmd/flags.go
@@ -61,5 +61,6 @@ func initSharedFlagSet() {
 	fMCP.Int("mcp-gid", -1, "if greater than -1, use as GID to run the MCP server command.")
 	fMCP.IntSlice("mcp-groups", nil, "additional GIDs to to run the MCP server command.")
 	fMCP.Bool("mcp-use-tempdir", false, "if set, create a new temp execution dir for each MCP server instance.")
-	fMCP.String("mcp-server-name", "", "the name of server.")
+	fMCP.String("mcp-tls-ca", "", "when using SSE, path to a CA to valide MCP server server certificates.")
+	fMCP.Bool("mcp-tls-insecure-skip-verify", false, "skip MCP server certificates validation. INSECURE.")
 }

--- a/pkgs/backend/client/interface.go
+++ b/pkgs/backend/client/interface.go
@@ -6,4 +6,5 @@ import "context"
 // act as a minibridge mcp Client.
 type Client interface {
 	Start(context.Context) (*MCPStream, error)
+	Type() string
 }

--- a/pkgs/backend/client/options.go
+++ b/pkgs/backend/client/options.go
@@ -11,30 +11,30 @@ type creds struct {
 	Groups []uint32
 }
 
-type cfg struct {
+type stdioCfg struct {
 	useTempDir bool
 	creds      *creds
 }
 
-func newCfg() cfg {
-	return cfg{}
+func newStdioCfg() stdioCfg {
+	return stdioCfg{}
 }
 
-// An Option can be passed to the Client.
-type Option func(*cfg)
+// An StdioOption can be passed to the Client.
+type StdioOption func(*stdioCfg)
 
-// OptUseTempDir defines if the the client should
+// OptStdioUseTempDir defines if the the client should
 // run the command into it's own working dir. If false,
 // the command will run in minibridge current cwd
-func OptUseTempDir(use bool) Option {
-	return func(c *cfg) {
+func OptStdioUseTempDir(use bool) StdioOption {
+	return func(c *stdioCfg) {
 		c.useTempDir = use
 	}
 }
 
-// OptCredentials sets the uid and gid to run the command as.
-func OptCredentials(uid int, gid int, groups []int) Option {
-	return func(c *cfg) {
+// OptStdioCredentials sets the uid and gid to run the command as.
+func OptStdioCredentials(uid int, gid int, groups []int) StdioOption {
+	return func(c *stdioCfg) {
 
 		grps := make([]uint32, 0, len(groups))
 

--- a/pkgs/backend/client/options_test.go
+++ b/pkgs/backend/client/options_test.go
@@ -10,45 +10,45 @@ import (
 func TestOptions(t *testing.T) {
 
 	Convey("OptUseTempDir should work", t, func() {
-		cfg := newCfg()
-		OptUseTempDir(true)(&cfg)
+		cfg := newStdioCfg()
+		OptStdioUseTempDir(true)(&cfg)
 		So(cfg.useTempDir, ShouldBeTrue)
 	})
 
 	Convey("OptCredentials should work", t, func() {
-		cfg := newCfg()
-		OptCredentials(1000, 1001, []int{2001, 2002})(&cfg)
+		cfg := newStdioCfg()
+		OptStdioCredentials(1000, 1001, []int{2001, 2002})(&cfg)
 		So(cfg.creds.Uid, ShouldEqual, 1000)
 		So(cfg.creds.Gid, ShouldEqual, 1001)
 		So(cfg.creds.Groups, ShouldResemble, []uint32{2001, 2002})
 	})
 
 	Convey("OptCredentials with -1 should work", t, func() {
-		cfg := newCfg()
-		OptCredentials(-1, -1, []int{-1})(&cfg)
+		cfg := newStdioCfg()
+		OptStdioCredentials(-1, -1, []int{-1})(&cfg)
 		So(cfg.creds, ShouldBeNil)
 	})
 
 	Convey("OptCredentials with only gid -1 should work", t, func() {
-		cfg := newCfg()
-		OptCredentials(100, -1, []int{-1})(&cfg)
+		cfg := newStdioCfg()
+		OptStdioCredentials(100, -1, []int{-1})(&cfg)
 		So(cfg.creds.Uid, ShouldEqual, 100)
 		So(cfg.creds.Gid, ShouldEqual, 0)
 		So(cfg.creds.Groups, ShouldResemble, []uint32{})
 	})
 
 	Convey("OptCredentials with uint32 overflow on uid should fail", t, func() {
-		cfg := newCfg()
-		So(func() { OptCredentials(math.MaxInt64, 1001, []int{2001, 2002})(&cfg) }, ShouldPanicWith, "invalid uid. overflows")
+		cfg := newStdioCfg()
+		So(func() { OptStdioCredentials(math.MaxInt64, 1001, []int{2001, 2002})(&cfg) }, ShouldPanicWith, "invalid uid. overflows")
 	})
 
 	Convey("OptCredentials with uint32 overflow on uid should fail", t, func() {
-		cfg := newCfg()
-		So(func() { OptCredentials(1, math.MaxInt64, []int{2001, 2002})(&cfg) }, ShouldPanicWith, "invalid gid. overflows")
+		cfg := newStdioCfg()
+		So(func() { OptStdioCredentials(1, math.MaxInt64, []int{2001, 2002})(&cfg) }, ShouldPanicWith, "invalid gid. overflows")
 	})
 
 	Convey("OptCredentials with uint32 overflow on groups should fail", t, func() {
-		cfg := newCfg()
-		So(func() { OptCredentials(1, 1, []int{2001, math.MaxInt64})(&cfg) }, ShouldPanicWith, "invalid group 1. overflows")
+		cfg := newStdioCfg()
+		So(func() { OptStdioCredentials(1, 1, []int{2001, math.MaxInt64})(&cfg) }, ShouldPanicWith, "invalid group 1. overflows")
 	})
 }

--- a/pkgs/backend/client/sse.go
+++ b/pkgs/backend/client/sse.go
@@ -1,0 +1,220 @@
+package client
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"go.acuvity.ai/minibridge/pkgs/internal/sanitize"
+)
+
+type sseClient struct {
+	endpoint        string
+	messageEndpoint string
+	client          *http.Client
+}
+
+func NewSSE(endpoint string, tlsConfig *tls.Config) Client {
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig:       tlsConfig,
+			ResponseHeaderTimeout: 10 * time.Second,
+		},
+	}
+
+	return &sseClient{
+		endpoint: endpoint,
+		client:   client,
+	}
+}
+
+func (c *sseClient) Type() string {
+	return "sse"
+}
+
+func (c *sseClient) Start(ctx context.Context) (pipe *MCPStream, err error) {
+
+	sseEndpoint := fmt.Sprintf("%s/sse", strings.TrimRight(c.endpoint, "/"))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sseEndpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to initiate request: %w", err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	// we don't close the body here (which makes the linter all triggered)
+	// because it's a long running connection. however readResponse will
+	// do it on exit
+	resp, err := c.client.Do(req) // nolint
+	if err != nil {
+		return nil, fmt.Errorf("unable to send initial sse request: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("invalid response from sse initialization: %s", resp.Status)
+	}
+
+	errCh := make(chan []byte)
+	exitCh := make(chan error)
+
+	inCh := make(chan []byte)
+	go c.readRequest(ctx, inCh, exitCh)
+
+	outCh := make(chan []byte)
+	go c.readResponse(ctx, resp.Body, outCh, exitCh)
+
+	// Get the first response to get the endpoint
+	var data []byte
+
+L:
+	for {
+		select {
+		case data = <-outCh:
+			break L
+
+		case err := <-exitCh:
+			if !errors.Is(err, io.EOF) {
+				return nil, fmt.Errorf("unable to process sse message: %w", err)
+			}
+
+		case <-time.After(3 * time.Second):
+			return nil, fmt.Errorf("did not receive /message endpoint in time")
+
+		case <-ctx.Done():
+			return nil, fmt.Errorf("did not receive /message endpoint in time: %w", ctx.Err())
+		}
+	}
+
+	c.messageEndpoint = fmt.Sprintf(
+		"%s/%s",
+		strings.TrimRight(c.endpoint, "/"),
+		strings.TrimLeft(string(data), "/"),
+	)
+	slog.Info("SSE Client: message endpoint set", "endpoint", c.messageEndpoint)
+
+	return &MCPStream{
+		Stdin:  inCh,
+		Stdout: outCh,
+		Stderr: errCh,
+		Exit:   exitCh,
+	}, nil
+}
+
+func (c *sseClient) readRequest(ctx context.Context, ch chan []byte, exitCh chan error) {
+
+	for {
+
+		select {
+
+		case <-ctx.Done():
+			return
+
+		case data := <-ch:
+
+			buf := bytes.NewBuffer(append(sanitize.Data(data), '\n', '\n'))
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.messageEndpoint, buf)
+			if err != nil {
+				exitCh <- fmt.Errorf("unable to make post request: %w", err)
+				return
+			}
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Accept", "application/json")
+
+			resp, err := c.client.Do(req)
+			if err != nil {
+				exitCh <- fmt.Errorf("unable to send post request: %w", err)
+				return
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusAccepted {
+				exitCh <- fmt.Errorf("invalid mcp server response status: %s", resp.Status)
+				return
+			}
+		}
+	}
+}
+
+func (c *sseClient) readResponse(ctx context.Context, r io.ReadCloser, ch chan []byte, exitCh chan error) {
+
+	defer func() { _ = r.Close() }()
+
+	scan := bufio.NewScanner(r)
+	scan.Split(split)
+
+	for scan.Scan() {
+
+		data := sanitize.Data(scan.Bytes())
+
+		parts := bytes.SplitN(data, []byte{'\n'}, 2)
+		if len(parts) != 2 {
+			exitCh <- fmt.Errorf("invalid sse message: %s", string(data))
+			return
+		}
+
+		data = bytes.TrimPrefix(parts[1], []byte("data: "))
+
+		select {
+		case ch <- data:
+		case <-ctx.Done():
+			return
+		}
+	}
+
+	if err := scan.Err(); err != nil {
+		exitCh <- fmt.Errorf("sse stream closed: %w", scan.Err())
+	} else {
+		exitCh <- fmt.Errorf("sse stream closed: %w", io.EOF)
+	}
+}
+
+func split(data []byte, atEOF bool) (int, []byte, error) {
+
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+
+	if i, nlen := hasNewLine(data); i >= 0 {
+		return i + nlen, data[0:i], nil
+	}
+
+	if atEOF {
+		return len(data), data, nil
+	}
+
+	return 0, nil, nil
+}
+
+func hasNewLine(data []byte) (int, int) {
+
+	crunix := bytes.Index(data, []byte("\n\n"))
+	crwin := bytes.Index(data, []byte("\r\n\r\n"))
+	minPos := minPos(crunix, crwin)
+	nlen := 2
+	if minPos == crwin {
+		nlen = 4
+	}
+	return minPos, nlen
+}
+
+func minPos(a, b int) int {
+	if a < 0 {
+		return b
+	}
+	if b < 0 {
+		return a
+	}
+	if a > b {
+		return b
+	}
+	return a
+}

--- a/pkgs/backend/client/sse_test.go
+++ b/pkgs/backend/client/sse_test.go
@@ -1,0 +1,350 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestSSEClient(t *testing.T) {
+
+	Convey("Type is correct", t, func() {
+		cl := NewSSE("https://127.0.0.1", nil)
+		So(cl.Type(), ShouldEqual, "sse")
+	})
+
+	Convey("Request fails to be made", t, func() {
+
+		cl := NewSSE("not-http://789.11.22.11", nil)
+
+		pipe, err := cl.Start(nil) // nolint
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldEqual, "unable to initiate request: net/http: nil Context")
+		So(pipe, ShouldBeNil)
+	})
+
+	Convey("Server does not respond", t, func() {
+
+		cl := NewSSE("http://789.11.22.11", nil)
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+
+		pipe, err := cl.Start(ctx)
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldEqual, "unable to send initial sse request: Get \"http://789.11.22.11/sse\": dial tcp: lookup 789.11.22.11: no such host")
+		So(pipe, ShouldBeNil)
+	})
+
+	Convey("Server does not return a message endpoint in time", t, func() {
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+		}))
+
+		cl := NewSSE(ts.URL, nil)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		pipe, err := cl.Start(ctx)
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldEqual, "did not receive /message endpoint in time")
+		So(pipe, ShouldBeNil)
+	})
+
+	Convey("Context cancels before sending the message endpoint", t, func() {
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+		}))
+
+		cl := NewSSE(ts.URL, nil)
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+
+		pipe, err := cl.Start(ctx)
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldEqual, "did not receive /message endpoint in time: context deadline exceeded")
+		So(pipe, ShouldBeNil)
+	})
+
+	Convey("Server does not respond with a valid status code", t, func() {
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusInsufficientStorage)
+		}))
+
+		cl := NewSSE(ts.URL, nil)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		pipe, err := cl.Start(ctx)
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldEqual, "invalid response from sse initialization: 507 Insufficient Storage")
+		So(pipe, ShouldBeNil)
+	})
+
+	Convey("Server returns an invalid message message", t, func() {
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("this is not sse\n\n"))
+		}))
+
+		cl := NewSSE(ts.URL, nil)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		pipe, err := cl.Start(ctx)
+		So(err, ShouldNotBeNil)
+		So(pipe, ShouldBeNil)
+		So(err.Error(), ShouldEqual, "unable to process sse message: invalid sse message: this is not sse")
+	})
+
+	Convey("Server returns a valid message endpoint", t, func() {
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("event: endpoint\ndata: /message?coucou=1\n\n"))
+		}))
+
+		cl := NewSSE(ts.URL, nil)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		pipe, err := cl.Start(ctx)
+		So(err, ShouldBeNil)
+		So(pipe, ShouldNotBeNil)
+		So(cl.(*sseClient).messageEndpoint, ShouldEqual, fmt.Sprintf("%s/message?coucou=1", ts.URL))
+	})
+
+	Convey("Client sends a message and server replies correctly", t, func() {
+
+		mutex := &sync.RWMutex{}
+
+		wait := make(chan struct{}, 2)
+		var rc *http.ResponseController
+		var rw http.ResponseWriter
+		var receivedMessage []byte
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+			if strings.HasSuffix(req.URL.String(), "/sse") {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("event: endpoint\ndata: /message?coucou=1\n\n"))
+
+				mutex.Lock()
+				rc = http.NewResponseController(w)
+				rw = w
+				_ = rc.Flush()
+				mutex.Unlock()
+
+				<-req.Context().Done()
+			}
+
+			mutex.RLock()
+			receivedMessage, _ = io.ReadAll(req.Body)
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = rw.Write([]byte("event: message\ndata: coucou\n\n"))
+			_ = rc.Flush()
+			mutex.RLock()
+
+			wait <- struct{}{}
+		}))
+
+		cl := NewSSE(ts.URL, nil)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		pipe, err := cl.Start(ctx)
+		So(err, ShouldBeNil)
+		So(pipe, ShouldNotBeNil)
+		So(cl.(*sseClient).messageEndpoint, ShouldEqual, fmt.Sprintf("%s/message?coucou=1", ts.URL))
+
+		pipe.Stdin <- []byte("this is a message")
+
+		<-wait
+
+		mutex.RLock()
+		So(string(receivedMessage), ShouldEqual, "this is a message\n\n")
+		mutex.RUnlock()
+
+		So(string(<-pipe.Stdout), ShouldEqual, "coucou")
+	})
+
+	Convey("Client sends a message and server replies with invalid sse message", t, func() {
+
+		mutex := &sync.RWMutex{}
+
+		wait := make(chan struct{})
+		var rc *http.ResponseController
+		var rw http.ResponseWriter
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+			if strings.HasSuffix(req.URL.String(), "/sse") {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("event: endpoint\ndata: /message?coucou=1\n\n"))
+
+				mutex.Lock()
+				rc = http.NewResponseController(w)
+				rw = w
+				_ = rc.Flush()
+				mutex.Unlock()
+
+				<-req.Context().Done()
+			}
+
+			mutex.RLock()
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = rw.Write([]byte("this is not sse\n\n"))
+			_ = rc.Flush()
+			mutex.RUnlock()
+
+			wait <- struct{}{}
+		}))
+
+		cl := NewSSE(ts.URL, nil)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		pipe, err := cl.Start(ctx)
+		So(err, ShouldBeNil)
+		So(pipe, ShouldNotBeNil)
+		So(cl.(*sseClient).messageEndpoint, ShouldEqual, fmt.Sprintf("%s/message?coucou=1", ts.URL))
+
+		pipe.Stdin <- []byte("this is a message")
+
+		<-wait
+		So((<-pipe.Exit).Error(), ShouldEqual, "invalid sse message: this is not sse")
+	})
+
+	Convey("Client sends a message and server replies with invalid status code", t, func() {
+
+		wait := make(chan struct{})
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+			if strings.HasSuffix(req.URL.String(), "/sse") {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("event: endpoint\ndata: /message?coucou=1\n\n"))
+				rc := http.NewResponseController(w)
+				_ = rc.Flush()
+				<-req.Context().Done()
+			}
+
+			w.WriteHeader(http.StatusNotAcceptable)
+			wait <- struct{}{}
+		}))
+
+		cl := NewSSE(ts.URL, nil)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		pipe, err := cl.Start(ctx)
+		So(err, ShouldBeNil)
+		So(pipe, ShouldNotBeNil)
+		So(cl.(*sseClient).messageEndpoint, ShouldEqual, fmt.Sprintf("%s/message?coucou=1", ts.URL))
+
+		pipe.Stdin <- []byte("this is a message")
+
+		<-wait
+		So((<-pipe.Exit).Error(), ShouldEqual, "invalid mcp server response status: 406 Not Acceptable")
+	})
+
+	Convey("Client sends a message but message endpoint is wrong", t, func() {
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+			if strings.HasSuffix(req.URL.String(), "/sse") {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("event: endpoint\ndata: /message?coucou=1\n\n"))
+				rc := http.NewResponseController(w)
+				_ = rc.Flush()
+				<-req.Context().Done()
+			}
+		}))
+
+		cl := NewSSE(ts.URL, nil)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		pipe, err := cl.Start(ctx)
+		So(err, ShouldBeNil)
+		So(pipe, ShouldNotBeNil)
+		cl.(*sseClient).messageEndpoint = "oh-no://999.999.999.999"
+
+		pipe.Stdin <- []byte("this is a message")
+
+		So((<-pipe.Exit).Error(), ShouldEqual, "unable to send post request: Post \"oh-no://999.999.999.999\": unsupported protocol scheme \"oh-no\"")
+	})
+
+	Convey("Client sends a message but message endpoint is not parseable", t, func() {
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+			if strings.HasSuffix(req.URL.String(), "/sse") {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("event: endpoint\ndata: /message?coucou=1\n\n"))
+				rc := http.NewResponseController(w)
+				_ = rc.Flush()
+				<-req.Context().Done()
+			}
+		}))
+
+		cl := NewSSE(ts.URL, nil)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		pipe, err := cl.Start(ctx)
+		So(err, ShouldBeNil)
+		So(pipe, ShouldNotBeNil)
+		cl.(*sseClient).messageEndpoint = "oh-no   :::::/999.999.999.999"
+
+		pipe.Stdin <- []byte("this is a message")
+
+		So((<-pipe.Exit).Error(), ShouldEqual, "unable to make post request: parse \"oh-no   :::::/999.999.999.999\": first path segment in URL cannot contain colon")
+	})
+
+	Convey("Client exits when server stops the connection", t, func() {
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+			if strings.HasSuffix(req.URL.String(), "/sse") {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("event: endpoint\ndata: /message?coucou=1\n\n"))
+				time.Sleep(time.Second)
+			}
+		}))
+
+		cl := NewSSE(ts.URL, nil)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		pipe, err := cl.Start(ctx)
+		So(err, ShouldBeNil)
+		So(pipe, ShouldNotBeNil)
+
+		So((<-pipe.Exit).Error(), ShouldEqual, "sse stream closed: EOF")
+	})
+
+}

--- a/pkgs/backend/client/stdio.go
+++ b/pkgs/backend/client/stdio.go
@@ -15,13 +15,13 @@ import (
 
 type stdioClient struct {
 	srv MCPServer
-	cfg cfg
+	cfg stdioCfg
 }
 
 // NewStdio returns a Client communicating through stdio.
-func NewStdio(srv MCPServer, options ...Option) Client {
+func NewStdio(srv MCPServer, options ...StdioOption) Client {
 
-	cfg := newCfg()
+	cfg := newStdioCfg()
 	for _, o := range options {
 		o(&cfg)
 	}
@@ -30,6 +30,10 @@ func NewStdio(srv MCPServer, options ...Option) Client {
 		srv: srv,
 		cfg: cfg,
 	}
+}
+
+func (c *stdioClient) Type() string {
+	return "stdio"
 }
 
 func (c *stdioClient) Start(ctx context.Context) (pipe *MCPStream, err error) {

--- a/pkgs/backend/client/stdio_test.go
+++ b/pkgs/backend/client/stdio_test.go
@@ -9,7 +9,12 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestClient(t *testing.T) {
+func TestStdioClient(t *testing.T) {
+
+	Convey("Type is correct", t, func() {
+		cl := NewStdio(MCPServer{})
+		So(cl.Type(), ShouldEqual, "stdio")
+	})
 
 	Convey("Given I have a client cat and I send lots of trailing \n", t, func() {
 
@@ -115,7 +120,7 @@ func TestClient(t *testing.T) {
 			Command: "sh",
 			Args:    []string{"-c", "touch testfile"},
 		}
-		cl := NewStdio(srv, OptUseTempDir(true))
+		cl := NewStdio(srv, OptStdioUseTempDir(true))
 
 		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()

--- a/pkgs/backend/options.go
+++ b/pkgs/backend/options.go
@@ -4,7 +4,6 @@ import (
 	"net"
 
 	"go.acuvity.ai/bahamut"
-	"go.acuvity.ai/minibridge/pkgs/backend/client"
 	"go.acuvity.ai/minibridge/pkgs/metrics"
 	"go.acuvity.ai/minibridge/pkgs/policer"
 	"go.acuvity.ai/minibridge/pkgs/scan"
@@ -13,7 +12,6 @@ import (
 )
 
 type wsCfg struct {
-	clientOpts      []client.Option
 	corsPolicy      *bahamut.CORSPolicy
 	dumpStderr      bool
 	listener        net.Listener
@@ -70,13 +68,6 @@ func OptCORSPolicy(policy *bahamut.CORSPolicy) Option {
 func OptSBOM(sbom scan.SBOM) Option {
 	return func(cfg *wsCfg) {
 		cfg.sbom = sbom
-	}
-}
-
-// OptClientOptions sets the option to pass to the spawned clients
-func OptClientOptions(opts ...client.Option) Option {
-	return func(cfg *wsCfg) {
-		cfg.clientOpts = opts
 	}
 }
 

--- a/pkgs/backend/options_test.go
+++ b/pkgs/backend/options_test.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 	"go.acuvity.ai/bahamut"
-	"go.acuvity.ai/minibridge/pkgs/backend/client"
 	"go.acuvity.ai/minibridge/pkgs/metrics"
 	"go.acuvity.ai/minibridge/pkgs/policer/api"
 	"go.acuvity.ai/minibridge/pkgs/scan"
@@ -50,13 +49,6 @@ func TestOptions(t *testing.T) {
 		s := scan.SBOM{}
 		OptSBOM(s)(&cfg)
 		So(cfg.sbom, ShouldEqual, s)
-	})
-
-	Convey("OptClientOtions should work", t, func() {
-		cfg := newWSCfg()
-		opts := []client.Option{client.OptUseTempDir(true)}
-		OptClientOptions(opts...)(&cfg)
-		So(cfg.clientOpts, ShouldResemble, opts)
 	})
 
 	Convey("OptMetricsManager should work", t, func() {

--- a/pkgs/backend/ws_test.go
+++ b/pkgs/backend/ws_test.go
@@ -36,8 +36,9 @@ func startBackend(ctx context.Context, opts ...Option) (wsc.Websocket, error) {
 	if err != nil {
 		return nil, err
 	}
+	client := client.NewStdio(srv)
 
-	backend := NewWebSocket(backendListen, nil, srv, opts...)
+	backend := NewWebSocket(backendListen, nil, client, opts...)
 
 	go func() {
 		if err := backend.Start(ctx); err != nil {

--- a/pkgs/frontend/internal/session/session.go
+++ b/pkgs/frontend/internal/session/session.go
@@ -153,6 +153,7 @@ func (s *Session) start() {
 				s.setDeadline(time.Now().Add(s.nextDeadline))
 
 			case err := <-s.ws.Done():
+				s.release()
 				s.closeCh <- err
 				return
 


### PR DESCRIPTION
backend and AIO mode are now able to connect to a remote MCP server using SSE. If the first CLI argument starts with http:// or https:// minibridge will connect to that MCP server using SSE. If not, it will run a local command and use stdio.