### PR TITLE
sbom: don't fail a sbom check if presented data is a subset of sbom

### DIFF
--- a/pkgs/backend/client/sse_test.go
+++ b/pkgs/backend/client/sse_test.go
@@ -155,6 +155,7 @@ func TestSSEClient(t *testing.T) {
 				mutex.Unlock()
 
 				<-req.Context().Done()
+				return
 			}
 
 			mutex.RLock()
@@ -212,6 +213,7 @@ func TestSSEClient(t *testing.T) {
 				mutex.Unlock()
 
 				<-req.Context().Done()
+				return
 			}
 
 			mutex.Lock()
@@ -255,6 +257,7 @@ func TestSSEClient(t *testing.T) {
 				rc := http.NewResponseController(w)
 				_ = rc.Flush()
 				<-req.Context().Done()
+				return
 			}
 
 			w.WriteHeader(http.StatusNotAcceptable)

--- a/pkgs/backend/client/stream_test.go
+++ b/pkgs/backend/client/stream_test.go
@@ -90,7 +90,7 @@ func TestMCPStream(t *testing.T) {
 		defer cancel()
 
 		done := make(chan bool, 1)
-		cstdin := make(chan []byte, 1)
+		cstdin := make(chan []byte, 2)
 		go func() {
 			cstdin <- <-stream.stdin
 			stream.stdout <- []byte(`{"id":"not-id"}`)

--- a/pkgs/scan/sbom.go
+++ b/pkgs/scan/sbom.go
@@ -68,16 +68,16 @@ type Hash struct {
 
 func cmpH(a Hashes, b Hashes) error {
 
-	if len(a) != len(b) {
+	if len(b) > len(a) {
 		return fmt.Errorf("invalid len. left: %d right: %d", len(a), len(b))
 	}
 
 	am := a.Map()
 	bm := b.Map()
 
-	for name, h := range am {
+	for name, h := range bm {
 
-		o, ok := bm[name]
+		o, ok := am[name]
 		if !ok {
 			return fmt.Errorf("'%s': missing", name)
 		}
@@ -86,9 +86,9 @@ func cmpH(a Hashes, b Hashes) error {
 			return fmt.Errorf("'%s': hash mismatch", name)
 		}
 
-		if len(h.Params) > 0 {
+		if len(o.Params) > 0 {
 
-			if err := cmpH(h.Params, o.Params); err != nil {
+			if err := cmpH(o.Params, h.Params); err != nil {
 				return fmt.Errorf("'%s': invalid param: %w", name, err)
 			}
 		}

--- a/pkgs/scan/sbom_test.go
+++ b/pkgs/scan/sbom_test.go
@@ -129,14 +129,8 @@ func TestSBOM_Matches(t *testing.T) {
 					},
 				}
 			},
-			true,
-			func(err error, t *testing.T) {
-				want := "'a1': invalid param: invalid len. left: 2 right: 1"
-				if err.Error() != want {
-					t.Logf("invalid err. want: %s got: %s", want, err.Error())
-					t.Fail()
-				}
-			},
+			false,
+			nil,
 		},
 		{
 			"extra param",
@@ -227,14 +221,8 @@ func TestSBOM_Matches(t *testing.T) {
 					},
 				}
 			},
-			true,
-			func(err error, t *testing.T) {
-				want := "invalid len. left: 2 right: 1"
-				if err.Error() != want {
-					t.Logf("invalid err. want: %s got: %s", want, err.Error())
-					t.Fail()
-				}
-			},
+			false,
+			nil,
 		},
 		{
 			"extra tool",
@@ -373,7 +361,7 @@ func TestSBOM_Matches(t *testing.T) {
 			},
 		},
 		{
-			"tool name missing",
+			"same len, different tool",
 			func(t *testing.T) Hashes {
 				return Hashes{
 					{
@@ -407,7 +395,7 @@ func TestSBOM_Matches(t *testing.T) {
 			},
 			true,
 			func(err error, t *testing.T) {
-				want := "'a1': missing"
+				want := "'b1': missing"
 				if err.Error() != want {
 					t.Logf("invalid err. want: %s got: %s", want, err.Error())
 					t.Fail()
@@ -415,7 +403,7 @@ func TestSBOM_Matches(t *testing.T) {
 			},
 		},
 		{
-			"param name missing left",
+			"param name missing",
 			func(t *testing.T) Hashes {
 				return Hashes{
 					{
@@ -449,7 +437,7 @@ func TestSBOM_Matches(t *testing.T) {
 			},
 			true,
 			func(err error, t *testing.T) {
-				want := "'a1': invalid param: 'p1': missing"
+				want := "'a1': invalid param: 'q1': missing"
 				if err.Error() != want {
 					t.Logf("invalid err. want: %s got: %s", want, err.Error())
 					t.Fail()


### PR DESCRIPTION
There are cases where the tools exposed by the MCP server may be a subset of the ones discovered when creating the SBOM. For instance if there is a privilege drop and the MCP server automatically remove SBOMed tools. In that case we don't consider this a failure. Extra objects are still an error, hash mismatch are also still an error